### PR TITLE
BMP280 Sensor Added 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 This respository holds implementations of various sensors.
 
 **This is Alpha Software**
+

--- a/fprime-sensors/Bmp280/CMakeLists.txt
+++ b/fprime-sensors/Bmp280/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Types/")
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Components/")
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Subtopology/") 

--- a/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
@@ -13,7 +13,7 @@ namespace Bmp280 {
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-BmpManager ::BmpManager(const char* const compName) : BmpManagerComponentBase(compName), m_state(RESET), m_resetAttempts(0) {}
+BmpManager ::BmpManager(const char* const compName) : BmpManagerComponentBase(compName), m_state(RESET) {}
 
 BmpManager ::~BmpManager() {}
 
@@ -55,18 +55,13 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
                 this->m_state = STARTUP_DELAY;
                 this->m_startupCounter = STARTUP_DELAY_CYCLES;
             } else {
-                m_resetAttempts++;
-                this->log_WARNING_HI_DeviceResetFailed(m_resetAttempts);
-                if (m_resetAttempts > MAX_RESET_ATTEMPTS) {
-                    this->log_WARNING_HI_DeviceFailure();
-                    m_resetAttempts = 0;
-                }
+                this->log_WARNING_HI_DeviceFailure();
             }
             break;
             
         case STARTUP_DELAY:
-            m_startupCounter--;
-            if (m_startupCounter <= 0) {
+            this->m_startupCounter--;
+            if (this->m_startupCounter <= 0) {
                 this->m_state = CHIP_ID_CHECK;
             }
             break;
@@ -78,11 +73,11 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
                     this->m_state = CALIBRATION_READ;
                 } else {
                     this->m_state = RESET;
-                    m_resetAttempts = 0;
+                    this->log_WARNING_HI_ChipIdCheckFailure();
                 }
             } else {
                 this->m_state = RESET;
-                m_resetAttempts = 0;
+                this->log_WARNING_HI_ChipIdCheckFailure();
             }
             break;
         }
@@ -91,7 +86,7 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
                 this->m_state = CONFIGURE;
             } else {
                 this->m_state = RESET;
-                m_resetAttempts = 0;
+                this->log_WARNING_HI_CalibrationFailure();
             }
             break;
         case CONFIGURE:
@@ -99,16 +94,24 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
                 this->m_state = RUNNING;
             } else {
                 this->m_state = RESET;
-                m_resetAttempts = 0;
+                this->log_WARNING_HI_DeviceConfigureFailure();
             }
             break;
         case RUNNING: {
+            // Reset throttles for logged events
+            this->log_WARNING_HI_DeviceFailure_ThrottleClear(); // Clear throttle for Device Failure event
+            this->log_WARNING_HI_ChipIdCheckFailure_ThrottleClear(); // Clear throttle for Chip ID Check Failure event
+            this->log_WARNING_HI_CalibrationFailure_ThrottleClear(); // Clear throttle for Data Calibration Failure event
+            this->log_WARNING_HI_DeviceConfigureFailure_ThrottleClear(); // Clear throttle for Device Configure Failure  event
+            this->log_WARNING_HI_MeasurementTriggerFailure_ThrottleClear(); // Clear throttle for Measurement Trigger Failure event
+            this->log_WARNING_HI_SpiTransferFailure_ThrottleClear(); // Clear throttle for SPI Transfer Failure event
+
+
             
             // Step 1: Check if measurement is ready
             U8 status = 0;
             if (!this->read_status(status)) {
                 this->m_state = RESET;
-                m_resetAttempts = 0;
                 break;
             }
             
@@ -120,7 +123,7 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
             // Step 2: Trigger a new measurement in forced mode
             if (!this->trigger_measurement()) {
                 this->m_state = RESET;
-                m_resetAttempts = 0;
+                this->log_WARNING_HI_MeasurementTriggerFailure();
                 break;
             }
             
@@ -145,13 +148,11 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
                 FW_ASSERT(paramValid != Fw::ParamValid::INVALID, static_cast<FwAssertArgType>(paramValid));
                 
                 const Bmp280Data bmpData = this->convert_raw_data(raw, this->m_calibration, seaLevelPressure);
-                printf("[BmpManager] Converted data - Pressure: %.2f Pa, Temperature: %.2f C, Altitude: %.2f m\n", 
-                       bmpData.getpressure(), bmpData.gettemperature(), bmpData.getaltitude());
+
                 this->tlmWrite_Reading(bmpData);
             } else {
-                printf("[BmpManager] ERROR: Failed to read measurement data. Resetting.\n");
                 this->m_state = RESET;
-                m_resetAttempts = 0;
+                this->log_WARNING_HI_SpiTransferFailure();
             }
             break;
         }
@@ -272,7 +273,7 @@ bool BmpManager ::configure_device() {
         success = this->spi_transfer(configWriteBuffer, configReadBuffer);
     }
     
-    return success;
+    return success; 
 }
 
 bool BmpManager ::trigger_measurement() {
@@ -296,15 +297,11 @@ bool BmpManager ::trigger_measurement() {
 
 bool BmpManager ::spi_transfer(Fw::Buffer& writeBuffer, Fw::Buffer& readBuffer) {
     // Validate buffer sizes
-    if (writeBuffer.getSize() == 0) {
-        this->log_WARNING_HI_SpiError(0, 1); // device=0, error=1 for empty buffer
-        return false;
-    }
-    
-    if (readBuffer.getSize() > 0 && readBuffer.getSize() != writeBuffer.getSize()) {
-        this->log_WARNING_HI_SpiError(0, 2); // device=0, error=2 for size mismatch  
-        return false;
-    }
+    FW_ASSERT(writeBuffer.getSize() == 0); 
+
+    FW_ASSERT(readBuffer.getSize() == 0); 
+
+    FW_ASSERT(writeBuffer.getSize() == readBuffer.getSize()); 
     
     // Perform the SPI transfer
     // Note: spiReadWrite_out calls the underlying SPI driver

--- a/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
@@ -6,7 +6,6 @@
 
 #include "fprime-sensors/Bmp280/Components/BmpManager/BmpManager.hpp"
 #include <cmath>
-#include <cstdio>  // For printf debugging
 
 namespace Bmp280 {
 
@@ -14,9 +13,7 @@ namespace Bmp280 {
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-BmpManager ::BmpManager(const char* const compName) : BmpManagerComponentBase(compName), m_state(RESET), m_resetAttempts(0) {
-    // printf("[BmpManager] Constructor: Starting in RESET state\n");
-}
+BmpManager ::BmpManager(const char* const compName) : BmpManagerComponentBase(compName), m_state(RESET), m_resetAttempts(0) {}
 
 BmpManager ::~BmpManager() {}
 
@@ -25,120 +22,91 @@ BmpManager ::~BmpManager() {}
 // ----------------------------------------------------------------------
 
 void BmpManager ::parameterUpdated(FwPrmIdType id) {
-    printf("[BmpManager] Parameter updated: ID=%d\n", static_cast<int>(id));
     Fw::ParamValid isValid = Fw::ParamValid::INVALID;
     switch (id) {
         case PARAMID_PRESSURE_OVERSAMPLING: {
-            // Read back the parameter value
             const PressureOversampling oversampling = this->paramGet_PRESSURE_OVERSAMPLING(isValid);
-            // NOTE: isValid is always VALID in parameterUpdated as it was just properly set
             FW_ASSERT(isValid == Fw::ParamValid::VALID, static_cast<FwAssertArgType>(isValid));
             this->log_ACTIVITY_HI_PressureOversamplingUpdated(oversampling);
-            // printf("[BmpManager] Pressure oversampling updated to %d, transitioning to CONFIGURE\n", static_cast<int>(oversampling.e));
             this->m_state = CONFIGURE;
             break;
         }
         case PARAMID_TEMPERATURE_OVERSAMPLING: {
-            // Read back the parameter value
             const TemperatureOversampling oversampling = this->paramGet_TEMPERATURE_OVERSAMPLING(isValid);
-            // NOTE: isValid is always VALID in parameterUpdated as it was just properly set
             FW_ASSERT(isValid == Fw::ParamValid::VALID, static_cast<FwAssertArgType>(isValid));
             this->log_ACTIVITY_HI_TemperatureOversamplingUpdated(oversampling);
-            // printf("[BmpManager] Temperature oversampling updated to %d, transitioning to CONFIGURE\n", static_cast<int>(oversampling.e));
             this->m_state = CONFIGURE;
             break;
         }
-        case PARAMID_SEA_LEVEL_PRESSURE: {
-            // printf("[BmpManager] Sea level pressure parameter updated - no reconfiguration needed\n");
+        case PARAMID_SEA_LEVEL_PRESSURE:
+            // Passive parameter, used in altitude calculation only
             break;
-        }
         default:
-            // printf("[BmpManager] ERROR: Unknown parameter ID %d\n", static_cast<int>(id));
             FW_ASSERT(0, static_cast<FwAssertArgType>(id));
             break;
     }
 }
 
 void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
-    // printf("[BmpManager] run_handler called, current state: %d\n", static_cast<int>(m_state));
-    
     switch (this->m_state) {
         case RESET:
-            // printf("[BmpManager] RESET state: attempt %d\n", m_resetAttempts);
             // If reset is successful, move to STARTUP_DELAY state
             if (this->reset()) {
-                // printf("[BmpManager] Reset command sent successfully, waiting for startup delay\n");
                 this->m_state = STARTUP_DELAY;
                 this->m_startupCounter = STARTUP_DELAY_CYCLES;
             } else {
-                // printf("[BmpManager] Reset command failed\n");
                 m_resetAttempts++;
+                this->log_WARNING_HI_DeviceResetFailed(m_resetAttempts);
                 if (m_resetAttempts > MAX_RESET_ATTEMPTS) {
-                    // printf("[BmpManager] ERROR: Maximum reset attempts exceeded\n");
-                    // Stay in RESET state but log error
+                    this->log_FATAL_DeviceFailure();
                     m_resetAttempts = 0;
                 }
             }
             break;
             
         case STARTUP_DELAY:
-            // printf("[BmpManager] STARTUP_DELAY state: %d cycles remaining\n", m_startupCounter);
             m_startupCounter--;
             if (m_startupCounter <= 0) {
-                // printf("[BmpManager] Startup delay complete, transitioning to CHIP_ID_CHECK\n");
                 this->m_state = CHIP_ID_CHECK;
             }
             break;
             
         case CHIP_ID_CHECK: {
-            // printf("[BmpManager] CHIP_ID_CHECK state\n");
             U8 chip_id = 0;
             if (this->read_chip_id(chip_id)) {
-                // printf("[BmpManager] Chip ID read successfully: 0x%02X\n", chip_id);
                 if (chip_id == CHIP_ID_VALUE) {
-                    // printf("[BmpManager] Chip ID matches expected value (0x%02X), transitioning to CALIBRATION_READ\n", CHIP_ID_VALUE);
                     this->m_state = CALIBRATION_READ;
                 } else {
-                    // printf("[BmpManager] ERROR: Chip ID mismatch. Expected 0x%02X, got 0x%02X. Resetting.\n", CHIP_ID_VALUE, chip_id);
                     this->m_state = RESET;
                     m_resetAttempts = 0;
                 }
             } else {
-                // printf("[BmpManager] ERROR: Failed to read chip ID. Resetting.\n");
                 this->m_state = RESET;
                 m_resetAttempts = 0;
             }
             break;
         }
         case CALIBRATION_READ:
-            //  printf("[BmpManager] CALIBRATION_READ state\n");
             if (this->read_calibration_data()) {
-                // printf("[BmpManager] Calibration data read successfully, transitioning to CONFIGURE\n");
                 this->m_state = CONFIGURE;
             } else {
-                // printf("[BmpManager] ERROR: Failed to read calibration data. Resetting.\n");
                 this->m_state = RESET;
                 m_resetAttempts = 0;
             }
             break;
         case CONFIGURE:
-            // printf("[BmpManager] CONFIGURE state\n");
             if (this->configure_device()) {
-                // printf("[BmpManager] Device configured successfully, transitioning to RUNNING\n");
                 this->m_state = RUNNING;
             } else {
-                // printf("[BmpManager] ERROR: Failed to configure device. Resetting.\n");
                 this->m_state = RESET;
                 m_resetAttempts = 0;
             }
             break;
         case RUNNING: {
-            // printf("[BmpManager] RUNNING state\n");
             
             // Step 1: Check if measurement is ready
             U8 status = 0;
             if (!this->read_status(status)) {
-                // printf("[BmpManager] ERROR: Failed to read status register. Resetting.\n");
                 this->m_state = RESET;
                 m_resetAttempts = 0;
                 break;
@@ -146,13 +114,11 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
             
             // Check if measurement is in progress (bit 3) or if data is being updated (bit 0)
             if ((status & 0x08) || (status & 0x01)) {
-                // printf("[BmpManager] Measurement in progress (status=0x%02X), waiting...\n", status);
                 break; // Wait for next cycle
             }
             
             // Step 2: Trigger a new measurement in forced mode
             if (!this->trigger_measurement()) {
-                // printf("[BmpManager] ERROR: Failed to trigger measurement. Resetting.\n");
                 this->m_state = RESET;
                 m_resetAttempts = 0;
                 break;
@@ -160,23 +126,19 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
             
             // Step 3: Read measurement data
             // BMP280 SPI protocol: read 6 bytes starting from PRESSURE_MSB_REGISTER
-            U8 spiData[MEASUREMENT_DATA_LENGTH + 1];
+            U8 spiData[MEASUREMENT_DATA_LENGTH + 1] = {0};
             spiData[0] = PRESSURE_MSB_REGISTER | 0x80; // Register address with MSB=1 for read
-            for (int i = 1; i <= MEASUREMENT_DATA_LENGTH; i++) {
-                spiData[i] = 0x00; // Dummy bytes
-            }
 
             Fw::Buffer writeBuffer(spiData, MEASUREMENT_DATA_LENGTH + 1);
             Fw::Buffer readBuffer(spiData, MEASUREMENT_DATA_LENGTH + 1);
             
             if (this->spi_transfer(writeBuffer, readBuffer)) {
-                // printf("[BmpManager] Raw measurement data read successfully\n");
                 
-                // Create buffer pointing to actual data (skip first byte which is register echo)
-                Fw::Buffer dataBuffer(&readBuffer.getData()[1], MEASUREMENT_DATA_LENGTH);
+                // Skip first byte (register echo) and deserialize measurement data directly
+                U8* dataPtr = &readBuffer.getData()[1];
+                Fw::Buffer dataBuffer(dataPtr, MEASUREMENT_DATA_LENGTH);
                 RawBmpData raw = this->deserialize_raw_data(dataBuffer);
-                printf("[BmpManager] Raw pressure: %u, Raw temperature: %u\n", raw.pressure, raw.temperature);
-                
+
                 // Get sea level pressure parameter
                 Fw::ParamValid paramValid;
                 F32 seaLevelPressure = this->paramGet_SEA_LEVEL_PRESSURE(paramValid);
@@ -194,7 +156,6 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
             break;
         }
         default:
-            // printf("[BmpManager] ERROR: Unknown state %d\n", static_cast<int>(m_state));
             FW_ASSERT(0, this->m_state);
             break;
     }
@@ -205,22 +166,15 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
 // ----------------------------------------------------------------------
 
 bool BmpManager ::reset() {
-    // printf("[BmpManager] Sending reset command (0x%02X -> 0x%02X)\n", RESET_REGISTER, RESET_VALUE);
-    // For SPI writes, register address MSB must be 0
     U8 reset_sequence[] = {RESET_REGISTER & 0x7F, RESET_VALUE}; // Clear MSB for write
     Fw::Buffer writeBuffer(reset_sequence, sizeof(reset_sequence));
     Fw::Buffer readBuffer;
     bool success = this->spi_transfer(writeBuffer, readBuffer);
-    // printf("[BmpManager] Reset command %s\n", success ? "succeeded" : "failed");
     return success;
 }
 
 bool BmpManager ::read_chip_id(U8& id) {
-    // printf("[BmpManager] Reading chip ID from register 0x%02X\n", CHIP_ID_REGISTER);
     
-    // BMP280 SPI protocol: for reads, MSB must be 1, and we need a 2-byte transaction
-    // Byte 0: Register address with MSB=1 (0xD0 | 0x80 = 0xD0, already has MSB set)
-    // Byte 1: Dummy byte (will be replaced with register value)
     U8 spiData[2] = {CHIP_ID_REGISTER | 0x80, 0x00}; // Ensure MSB is set for read
     
     Fw::Buffer writeBuffer(spiData, 2);
@@ -229,20 +183,15 @@ bool BmpManager ::read_chip_id(U8& id) {
     bool success = this->spi_transfer(writeBuffer, readBuffer);
     
     if (success) {
-        // The chip ID will be in the second byte of the response
         id = readBuffer.getData()[1];
-        // printf("[BmpManager] Chip ID read: 0x%02X\n", id);
     } else {
-        // printf("[BmpManager] Failed to read chip ID\n");
         id = 0;
     }
     return success;
 }
 
 bool BmpManager ::read_status(U8& status) {
-    // printf("[BmpManager] Reading status from register 0x%02X\n", STATUS_REGISTER);
     
-    // BMP280 SPI protocol: 2-byte transaction for register read
     U8 spiData[2] = {STATUS_REGISTER | 0x80, 0x00}; // Ensure MSB is set for read
     
     Fw::Buffer writeBuffer(spiData, 2);
@@ -252,9 +201,7 @@ bool BmpManager ::read_status(U8& status) {
     
     if (success) {
         status = readBuffer.getData()[1];
-        // printf("[BmpManager] Status read: 0x%02X\n", status);
     } else {
-        // printf("[BmpManager] Failed to read status\n");
         status = 0;
     }
     
@@ -262,14 +209,10 @@ bool BmpManager ::read_status(U8& status) {
 }
 
 bool BmpManager ::read_calibration_data() {
-    // printf("[BmpManager] Reading calibration data from register 0x%02X, length %d bytes\n", 
-    //        CALIB_DATA_REGISTER, CALIB_DATA_LENGTH);
     
-    // BMP280 SPI protocol: for multi-byte read, send register address + read 24 bytes
-    // Total transaction: 1 byte register address + 24 bytes data = 25 bytes
     U8 spiData[CALIB_DATA_LENGTH + 1];
     spiData[0] = CALIB_DATA_REGISTER | 0x80; // Register address with MSB=1 for read
-    for (int i = 1; i <= CALIB_DATA_LENGTH; i++) {
+    for (U32 i = 1; i <= CALIB_DATA_LENGTH; i++) {
         spiData[i] = 0x00; // Dummy bytes that will be filled with calibration data
     }
     
@@ -277,11 +220,8 @@ bool BmpManager ::read_calibration_data() {
     Fw::Buffer readBuffer(spiData, CALIB_DATA_LENGTH + 1);
     
     if (this->spi_transfer(writeBuffer, readBuffer)) {
-        // printf("[BmpManager] Calibration data read successfully, parsing coefficients\n");
         
-        // Parse calibration data from the buffer (skip first byte which is the register echo)
-        // Registers 0x88-0x9F contain 12 calibration coefficients (24 bytes)
-        U8* data = &readBuffer.getData()[1]; // Skip the first byte (register address echo)
+        U8* data = &readBuffer.getData()[1];
         
         m_calibration.dig_T1 = (static_cast<U16>(data[1]) << 8) | data[0];
         m_calibration.dig_T2 = (static_cast<I16>(data[3]) << 8) | data[2];
@@ -297,27 +237,19 @@ bool BmpManager ::read_calibration_data() {
         m_calibration.dig_P8 = (static_cast<I16>(data[21]) << 8) | data[20];
         m_calibration.dig_P9 = (static_cast<I16>(data[23]) << 8) | data[22];
         
-        // printf("[BmpManager] Calibration coefficients:\n");
-        // printf("  dig_T1=%u, dig_T2=%d, dig_T3=%d\n", m_calibration.dig_T1, m_calibration.dig_T2, m_calibration.dig_T3);
-        // printf("  dig_P1=%u, dig_P2=%d, dig_P3=%d\n", m_calibration.dig_P1, m_calibration.dig_P2, m_calibration.dig_P3);
-        // printf("  dig_P4=%d, dig_P5=%d, dig_P6=%d\n", m_calibration.dig_P4, m_calibration.dig_P5, m_calibration.dig_P6);
-        // printf("  dig_P7=%d, dig_P8=%d, dig_P9=%d\n", m_calibration.dig_P7, m_calibration.dig_P8, m_calibration.dig_P9);
-        
         return true;
     }
-    printf("[BmpManager] Failed to read calibration data\n");
     return false;
 }
 
 bool BmpManager ::configure_device() {
-    // printf("[BmpManager] Configuring device\n");
     Fw::ParamValid paramValid;
     const PressureOversampling pressureOversampling = this->paramGet_PRESSURE_OVERSAMPLING(paramValid);
     FW_ASSERT(paramValid != Fw::ParamValid::INVALID, static_cast<FwAssertArgType>(paramValid));
     const TemperatureOversampling temperatureOversampling = this->paramGet_TEMPERATURE_OVERSAMPLING(paramValid);
     FW_ASSERT(paramValid != Fw::ParamValid::INVALID, static_cast<FwAssertArgType>(paramValid));
 
-    // According to datasheet, CTRL_MEAS register (0xF4) format:
+    // CTRL_MEAS register (0xF4) format:
     // bits 7:5 = osrs_t (temperature oversampling)  
     // bits 4:2 = osrs_p (pressure oversampling)
     // bits 1:0 = mode (00=sleep, 01=forced, 11=normal)
@@ -325,10 +257,6 @@ bool BmpManager ::configure_device() {
                          (static_cast<U8>(pressureOversampling) << 2) | 
                          0x00; // Start in sleep mode first
     
-    //printf("[BmpManager] Setting CTRL_MEAS register to 0x%02X (temp_os=%d, press_os=%d, mode=sleep)\n", 
-        //    ctrl_meas_value, static_cast<int>(temperatureOversampling.e), static_cast<int>(pressureOversampling.e));
-    
-    // For SPI writes, register address MSB must be 0
     U8 config_sequence[] = {CTRL_MEAS_REGISTER & 0x7F, ctrl_meas_value}; // Clear MSB for write
     Fw::Buffer writeBuffer(config_sequence, sizeof(config_sequence));
     Fw::Buffer readBuffer;
@@ -336,25 +264,18 @@ bool BmpManager ::configure_device() {
     bool success = this->spi_transfer(writeBuffer, readBuffer);
     
     if (success) {
-        // Also configure the CONFIG register (0xF5) for IIR filter and standby time
-        // bits 7:5 = t_sb (standby time in normal mode) - not used in forced mode
-        // bits 4:2 = filter (IIR filter coefficient)
-        // bit 0 = spi3w_en (3-wire SPI enable)
         U8 config_value = 0x00; // No IIR filter, 4-wire SPI
         U8 config_sequence[] = {CONFIG_REGISTER & 0x7F, config_value}; // Clear MSB for write
         Fw::Buffer configWriteBuffer(config_sequence, sizeof(config_sequence));
         Fw::Buffer configReadBuffer;
         
-        // printf("[BmpManager] Setting CONFIG register to 0x%02X\n", config_value);
         success = this->spi_transfer(configWriteBuffer, configReadBuffer);
     }
     
-    // printf("[BmpManager] Device configuration %s\n", success ? "succeeded" : "failed");
     return success;
 }
 
 bool BmpManager ::trigger_measurement() {
-    // printf("[BmpManager] Triggering measurement in forced mode\n");
     Fw::ParamValid paramValid;
     const PressureOversampling pressureOversampling = this->paramGet_PRESSURE_OVERSAMPLING(paramValid);
     FW_ASSERT(paramValid != Fw::ParamValid::INVALID, static_cast<FwAssertArgType>(paramValid));
@@ -374,33 +295,22 @@ bool BmpManager ::trigger_measurement() {
 }
 
 bool BmpManager ::spi_transfer(Fw::Buffer& writeBuffer, Fw::Buffer& readBuffer) {
-    // printf("[BmpManager] SPI transfer: writing %d bytes, reading %d bytes\n", 
-    //        writeBuffer.getSize(), readBuffer.getSize());
+    // Validate buffer sizes
+    if (writeBuffer.getSize() == 0) {
+        this->log_WARNING_HI_SpiError(0, 1); // device=0, error=1 for empty buffer
+        return false;
+    }
     
-    // Print write data for debugging
-    if (writeBuffer.getSize() > 0) {
-        // printf("[BmpManager] Write data: ");
-        for (U32 i = 0; i < writeBuffer.getSize(); i++) {
-            // printf("0x%02X ", writeBuffer.getData()[i]);
-        }
-        // printf("\n");
+    if (readBuffer.getSize() > 0 && readBuffer.getSize() != writeBuffer.getSize()) {
+        this->log_WARNING_HI_SpiError(0, 2); // device=0, error=2 for size mismatch  
+        return false;
     }
     
     // Perform the SPI transfer
+    // Note: spiReadWrite_out calls the underlying SPI driver
     this->spiReadWrite_out(0, writeBuffer, readBuffer);
     
-    // Print read data for debugging
-    // if (readBuffer.getSize() > 0) {
-    //     printf("[BmpManager] Read data: ");
-    //     for (U32 i = 0; i < readBuffer.getSize(); i++) {
-    //         printf("0x%02X ", readBuffer.getData()[i]);
-    //     }
-    //     printf("\n");
-    // }
-    
-    // TODO: In a real implementation, we should check for SPI errors
-    // For now, we assume success but this is where error detection should be added
-    // The Linux SPI driver logs warnings internally if ioctl fails
+    // Linux SPI driver logs warnings internally if ioctl fails 
     return true;
 }
 
@@ -464,9 +374,6 @@ Bmp280Data BmpManager ::convert_raw_data(const RawBmpData& raw, const Calibratio
     // Calculate altitude using barometric formula
     F32 altitude = calculate_altitude(pressure, seaLevelPressure);
     
-    // printf("[BmpManager] Temperature compensation: raw=%u -> %.2f°C (t_fine=%d)\n", raw.temperature, temperature, t_fine);
-    // printf("[BmpManager] Pressure compensation: raw=%u -> %.2f Pa\n", raw.pressure, pressure);
-    
     bmpData.setpressure(pressure);
     bmpData.settemperature(temperature);
     bmpData.setaltitude(altitude);
@@ -474,38 +381,23 @@ Bmp280Data BmpManager ::convert_raw_data(const RawBmpData& raw, const Calibratio
     return bmpData;
 }
 
-U8 BmpManager ::pressure_oversampling_to_register(PressureOversampling oversampling) {
-    return static_cast<U8>(oversampling);
-}
-
-U8 BmpManager ::temperature_oversampling_to_register(TemperatureOversampling oversampling) {
-    return static_cast<U8>(oversampling);
-}
-
 F32 BmpManager ::calculate_altitude(F32 pressure, F32 seaLevelPressure) {
-    // Barometric formula for altitude calculation
-    // altitude = 44330 * (1 - (pressure / seaLevelPressure)^(1/5.255))
-    
-    // printf("[BmpManager] Calculating altitude: pressure=%.2f Pa, sea_level=%.2f Pa\n", pressure, seaLevelPressure);
-    
     if (seaLevelPressure <= 0.0f || pressure <= 0.0f) {
-        // printf("[BmpManager] ERROR: Invalid pressure values for altitude calculation\n");
         return 0.0f;  // Return 0 for invalid inputs
     }
     
     F32 ratio = pressure / seaLevelPressure;
     if (ratio <= 0.0f) {
-        // printf("[BmpManager] ERROR: Invalid pressure ratio for altitude calculation\n");
         return 0.0f;
     }
     
     // Using standard atmosphere model constants
+    // Barometric formula for altitude calculation
+    // altitude = 44330 * (1 - (pressure / seaLevelPressure)^(1/5.255))
     static const F32 STANDARD_ALTITUDE_CONSTANT = 44330.0f;
     static const F32 PRESSURE_EXPONENT = 1.0f / 5.255f;
     
     F32 altitude = STANDARD_ALTITUDE_CONSTANT * (1.0f - pow(ratio, PRESSURE_EXPONENT));
-    
-    // printf("[BmpManager] Altitude calculated: %.2f m (ratio=%.4f)\n", altitude, ratio);
     
     return altitude;
 }

--- a/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
@@ -6,6 +6,7 @@
 
 #include "fprime-sensors/Bmp280/Components/BmpManager/BmpManager.hpp"
 #include <cmath>
+#include <cstdio>  // For printf debugging
 
 namespace Bmp280 {
 
@@ -13,7 +14,9 @@ namespace Bmp280 {
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-BmpManager ::BmpManager(const char* const compName) : BmpManagerComponentBase(compName), m_state(RESET) {}
+BmpManager ::BmpManager(const char* const compName) : BmpManagerComponentBase(compName), m_state(RESET), m_resetAttempts(0) {
+    printf("[BmpManager] Constructor: Starting in RESET state\n");
+}
 
 BmpManager ::~BmpManager() {}
 
@@ -22,6 +25,7 @@ BmpManager ::~BmpManager() {}
 // ----------------------------------------------------------------------
 
 void BmpManager ::parameterUpdated(FwPrmIdType id) {
+    printf("[BmpManager] Parameter updated: ID=%d\n", static_cast<int>(id));
     Fw::ParamValid isValid = Fw::ParamValid::INVALID;
     switch (id) {
         case PARAMID_PRESSURE_OVERSAMPLING: {
@@ -30,6 +34,7 @@ void BmpManager ::parameterUpdated(FwPrmIdType id) {
             // NOTE: isValid is always VALID in parameterUpdated as it was just properly set
             FW_ASSERT(isValid == Fw::ParamValid::VALID, static_cast<FwAssertArgType>(isValid));
             this->log_ACTIVITY_HI_PressureOversamplingUpdated(oversampling);
+            printf("[BmpManager] Pressure oversampling updated to %d, transitioning to CONFIGURE\n", static_cast<int>(oversampling.e));
             this->m_state = CONFIGURE;
             break;
         }
@@ -39,55 +44,121 @@ void BmpManager ::parameterUpdated(FwPrmIdType id) {
             // NOTE: isValid is always VALID in parameterUpdated as it was just properly set
             FW_ASSERT(isValid == Fw::ParamValid::VALID, static_cast<FwAssertArgType>(isValid));
             this->log_ACTIVITY_HI_TemperatureOversamplingUpdated(oversampling);
+            printf("[BmpManager] Temperature oversampling updated to %d, transitioning to CONFIGURE\n", static_cast<int>(oversampling.e));
             this->m_state = CONFIGURE;
             break;
         }
         case PARAMID_SEA_LEVEL_PRESSURE: {
-            // Sea level pressure parameter updated - no need to reconfigure device
+            printf("[BmpManager] Sea level pressure parameter updated - no reconfiguration needed\n");
             break;
         }
         default:
+            printf("[BmpManager] ERROR: Unknown parameter ID %d\n", static_cast<int>(id));
             FW_ASSERT(0, static_cast<FwAssertArgType>(id));
             break;
     }
 }
 
 void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
+    printf("[BmpManager] run_handler called, current state: %d\n", static_cast<int>(m_state));
+    
     switch (this->m_state) {
         case RESET:
-            // If reset is successful, move to CHIP_ID_CHECK state
+            printf("[BmpManager] RESET state: attempt %d\n", m_resetAttempts);
+            // If reset is successful, move to STARTUP_DELAY state
             if (this->reset()) {
+                printf("[BmpManager] Reset command sent successfully, waiting for startup delay\n");
+                this->m_state = STARTUP_DELAY;
+                this->m_startupCounter = STARTUP_DELAY_CYCLES;
+            } else {
+                printf("[BmpManager] Reset command failed\n");
+                m_resetAttempts++;
+                if (m_resetAttempts > MAX_RESET_ATTEMPTS) {
+                    printf("[BmpManager] ERROR: Maximum reset attempts exceeded\n");
+                    // Stay in RESET state but log error
+                    m_resetAttempts = 0;
+                }
+            }
+            break;
+            
+        case STARTUP_DELAY:
+            printf("[BmpManager] STARTUP_DELAY state: %d cycles remaining\n", m_startupCounter);
+            m_startupCounter--;
+            if (m_startupCounter <= 0) {
+                printf("[BmpManager] Startup delay complete, transitioning to CHIP_ID_CHECK\n");
                 this->m_state = CHIP_ID_CHECK;
             }
             break;
+            
         case CHIP_ID_CHECK: {
+            printf("[BmpManager] CHIP_ID_CHECK state\n");
             U8 chip_id = 0;
             if (this->read_chip_id(chip_id)) {
+                printf("[BmpManager] Chip ID read successfully: 0x%02X\n", chip_id);
                 if (chip_id == CHIP_ID_VALUE) {
+                    printf("[BmpManager] Chip ID matches expected value (0x%02X), transitioning to CALIBRATION_READ\n", CHIP_ID_VALUE);
                     this->m_state = CALIBRATION_READ;
                 } else {
+                    printf("[BmpManager] ERROR: Chip ID mismatch. Expected 0x%02X, got 0x%02X. Resetting.\n", CHIP_ID_VALUE, chip_id);
                     this->m_state = RESET;
+                    m_resetAttempts = 0;
                 }
             } else {
+                printf("[BmpManager] ERROR: Failed to read chip ID. Resetting.\n");
                 this->m_state = RESET;
+                m_resetAttempts = 0;
             }
             break;
         }
         case CALIBRATION_READ:
+            printf("[BmpManager] CALIBRATION_READ state\n");
             if (this->read_calibration_data()) {
+                printf("[BmpManager] Calibration data read successfully, transitioning to CONFIGURE\n");
                 this->m_state = CONFIGURE;
             } else {
+                printf("[BmpManager] ERROR: Failed to read calibration data. Resetting.\n");
                 this->m_state = RESET;
+                m_resetAttempts = 0;
             }
             break;
         case CONFIGURE:
+            printf("[BmpManager] CONFIGURE state\n");
             if (this->configure_device()) {
+                printf("[BmpManager] Device configured successfully, transitioning to RUNNING\n");
                 this->m_state = RUNNING;
             } else {
+                printf("[BmpManager] ERROR: Failed to configure device. Resetting.\n");
                 this->m_state = RESET;
+                m_resetAttempts = 0;
             }
             break;
         case RUNNING: {
+            printf("[BmpManager] RUNNING state\n");
+            
+            // Step 1: Check if measurement is ready
+            U8 status = 0;
+            if (!this->read_status(status)) {
+                printf("[BmpManager] ERROR: Failed to read status register. Resetting.\n");
+                this->m_state = RESET;
+                m_resetAttempts = 0;
+                break;
+            }
+            
+            // Check if measurement is in progress (bit 3) or if data is being updated (bit 0)
+            if ((status & 0x08) || (status & 0x01)) {
+                printf("[BmpManager] Measurement in progress (status=0x%02X), waiting...\n", status);
+                break; // Wait for next cycle
+            }
+            
+            // Step 2: Trigger a new measurement in forced mode
+            if (!this->trigger_measurement()) {
+                printf("[BmpManager] ERROR: Failed to trigger measurement. Resetting.\n");
+                this->m_state = RESET;
+                m_resetAttempts = 0;
+                break;
+            }
+            
+            // Step 3: Read measurement data
             U8 data[MEASUREMENT_DATA_LENGTH];
             U8 registerAddress = PRESSURE_MSB_REGISTER;
 
@@ -95,7 +166,9 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
             Fw::Buffer readBuffer(data, MEASUREMENT_DATA_LENGTH);
             
             if (this->spi_transfer(writeBuffer, readBuffer)) {
+                printf("[BmpManager] Raw measurement data read successfully\n");
                 RawBmpData raw = this->deserialize_raw_data(readBuffer);
+                printf("[BmpManager] Raw pressure: %u, Raw temperature: %u\n", raw.pressure, raw.temperature);
                 
                 // Get sea level pressure parameter
                 Fw::ParamValid paramValid;
@@ -103,13 +176,18 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
                 FW_ASSERT(paramValid != Fw::ParamValid::INVALID, static_cast<FwAssertArgType>(paramValid));
                 
                 const Bmp280Data bmpData = this->convert_raw_data(raw, this->m_calibration, seaLevelPressure);
+                printf("[BmpManager] Converted data - Pressure: %.2f Pa, Temperature: %.2f C, Altitude: %.2f m\n", 
+                       bmpData.getpressure(), bmpData.gettemperature(), bmpData.getaltitude());
                 this->tlmWrite_Reading(bmpData);
             } else {
+                printf("[BmpManager] ERROR: Failed to read measurement data. Resetting.\n");
                 this->m_state = RESET;
+                m_resetAttempts = 0;
             }
             break;
         }
         default:
+            printf("[BmpManager] ERROR: Unknown state %d\n", static_cast<int>(m_state));
             FW_ASSERT(0, this->m_state);
             break;
     }
@@ -120,20 +198,39 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
 // ----------------------------------------------------------------------
 
 bool BmpManager ::reset() {
+    printf("[BmpManager] Sending reset command (0x%02X -> 0x%02X)\n", RESET_REGISTER, RESET_VALUE);
     U8 reset_sequence[] = {RESET_REGISTER, RESET_VALUE};
     Fw::Buffer writeBuffer(reset_sequence, sizeof(reset_sequence));
     Fw::Buffer readBuffer;
-    return this->spi_transfer(writeBuffer, readBuffer);
+    bool success = this->spi_transfer(writeBuffer, readBuffer);
+    printf("[BmpManager] Reset command %s\n", success ? "succeeded" : "failed");
+    return success;
 }
 
 bool BmpManager ::read_chip_id(U8& id) {
+    printf("[BmpManager] Reading chip ID from register 0x%02X\n", CHIP_ID_REGISTER);
     U8 registerAddress = CHIP_ID_REGISTER;
     Fw::Buffer writeBuffer(&registerAddress, 1);
     Fw::Buffer readBuffer(&id, 1);
+    bool success = this->spi_transfer(writeBuffer, readBuffer);
+    if (success) {
+        printf("[BmpManager] Chip ID read: 0x%02X\n", id);
+    } else {
+        printf("[BmpManager] Failed to read chip ID\n");
+    }
+    return success;
+}
+
+bool BmpManager ::read_status(U8& status) {
+    U8 registerAddress = STATUS_REGISTER;
+    Fw::Buffer writeBuffer(&registerAddress, 1);
+    Fw::Buffer readBuffer(&status, 1);
     return this->spi_transfer(writeBuffer, readBuffer);
 }
 
 bool BmpManager ::read_calibration_data() {
+    printf("[BmpManager] Reading calibration data from register 0x%02X, length %d bytes\n", 
+           CALIB_DATA_REGISTER, CALIB_DATA_LENGTH);
     U8 data[CALIB_DATA_LENGTH];
     U8 registerAddress = CALIB_DATA_REGISTER;
     Fw::Buffer writeBuffer(&registerAddress, 1);
@@ -145,18 +242,64 @@ bool BmpManager ::read_calibration_data() {
         // Implementation would parse calibration coefficients
         return true;
     }
+    printf("[BmpManager] Failed to read calibration data\n");
     return false;
 }
 
 bool BmpManager ::configure_device() {
+    printf("[BmpManager] Configuring device\n");
     Fw::ParamValid paramValid;
     const PressureOversampling pressureOversampling = this->paramGet_PRESSURE_OVERSAMPLING(paramValid);
     FW_ASSERT(paramValid != Fw::ParamValid::INVALID, static_cast<FwAssertArgType>(paramValid));
     const TemperatureOversampling temperatureOversampling = this->paramGet_TEMPERATURE_OVERSAMPLING(paramValid);
     FW_ASSERT(paramValid != Fw::ParamValid::INVALID, static_cast<FwAssertArgType>(paramValid));
 
-    U8 ctrl_meas_value = static_cast<U8>(temperatureOversampling) | 
-                         static_cast<U8>(pressureOversampling) | 
+    // According to datasheet, CTRL_MEAS register (0xF4) format:
+    // bits 7:5 = osrs_t (temperature oversampling)  
+    // bits 4:2 = osrs_p (pressure oversampling)
+    // bits 1:0 = mode (00=sleep, 01=forced, 11=normal)
+    U8 ctrl_meas_value = (static_cast<U8>(temperatureOversampling) << 5) | 
+                         (static_cast<U8>(pressureOversampling) << 2) | 
+                         0x00; // Start in sleep mode first
+    
+    printf("[BmpManager] Setting CTRL_MEAS register to 0x%02X (temp_os=%d, press_os=%d, mode=sleep)\n", 
+           ctrl_meas_value, static_cast<int>(temperatureOversampling.e), static_cast<int>(pressureOversampling.e));
+    
+    U8 config_sequence[] = {CTRL_MEAS_REGISTER, ctrl_meas_value};
+    Fw::Buffer writeBuffer(config_sequence, sizeof(config_sequence));
+    Fw::Buffer readBuffer;
+    
+    bool success = this->spi_transfer(writeBuffer, readBuffer);
+    
+    if (success) {
+        // Also configure the CONFIG register (0xF5) for IIR filter and standby time
+        // bits 7:5 = t_sb (standby time in normal mode) - not used in forced mode
+        // bits 4:2 = filter (IIR filter coefficient)
+        // bit 0 = spi3w_en (3-wire SPI enable)
+        U8 config_value = 0x00; // No IIR filter, 4-wire SPI
+        U8 config_sequence[] = {CONFIG_REGISTER, config_value};
+        Fw::Buffer configWriteBuffer(config_sequence, sizeof(config_sequence));
+        Fw::Buffer configReadBuffer;
+        
+        printf("[BmpManager] Setting CONFIG register to 0x%02X\n", config_value);
+        success = this->spi_transfer(configWriteBuffer, configReadBuffer);
+    }
+    
+    printf("[BmpManager] Device configuration %s\n", success ? "succeeded" : "failed");
+    return success;
+}
+
+bool BmpManager ::trigger_measurement() {
+    printf("[BmpManager] Triggering measurement in forced mode\n");
+    Fw::ParamValid paramValid;
+    const PressureOversampling pressureOversampling = this->paramGet_PRESSURE_OVERSAMPLING(paramValid);
+    FW_ASSERT(paramValid != Fw::ParamValid::INVALID, static_cast<FwAssertArgType>(paramValid));
+    const TemperatureOversampling temperatureOversampling = this->paramGet_TEMPERATURE_OVERSAMPLING(paramValid);
+    FW_ASSERT(paramValid != Fw::ParamValid::INVALID, static_cast<FwAssertArgType>(paramValid));
+
+    // Set device to forced mode to trigger a measurement
+    U8 ctrl_meas_value = (static_cast<U8>(temperatureOversampling) << 5) | 
+                         (static_cast<U8>(pressureOversampling) << 2) | 
                          FORCED_MODE;
     
     U8 config_sequence[] = {CTRL_MEAS_REGISTER, ctrl_meas_value};
@@ -166,9 +309,33 @@ bool BmpManager ::configure_device() {
 }
 
 bool BmpManager ::spi_transfer(Fw::Buffer& writeBuffer, Fw::Buffer& readBuffer) {
-    // For SPI, we need to handle the transaction differently
-    // SPI typically requires a single transfer with combined write/read buffer
+    printf("[BmpManager] SPI transfer: writing %d bytes, reading %d bytes\n", 
+           writeBuffer.getSize(), readBuffer.getSize());
+    
+    // Print write data for debugging
+    if (writeBuffer.getSize() > 0) {
+        printf("[BmpManager] Write data: ");
+        for (U32 i = 0; i < writeBuffer.getSize(); i++) {
+            printf("0x%02X ", writeBuffer.getData()[i]);
+        }
+        printf("\n");
+    }
+    
+    // Perform the SPI transfer
     this->spiReadWrite_out(0, writeBuffer, readBuffer);
+    
+    // Print read data for debugging
+    if (readBuffer.getSize() > 0) {
+        printf("[BmpManager] Read data: ");
+        for (U32 i = 0; i < readBuffer.getSize(); i++) {
+            printf("0x%02X ", readBuffer.getData()[i]);
+        }
+        printf("\n");
+    }
+    
+    // TODO: In a real implementation, we should check for SPI errors
+    // For now, we assume success but this is where error detection should be added
+    // The Linux SPI driver logs warnings internally if ioctl fails
     return true;
 }
 
@@ -198,15 +365,42 @@ BmpManager::RawBmpData BmpManager ::deserialize_raw_data(Fw::Buffer& buffer) {
 
 Bmp280Data BmpManager ::convert_raw_data(const RawBmpData& raw, const CalibrationData& calib, F32 seaLevelPressure) {
     Bmp280Data bmpData;
-    // Implementation would use calibration coefficients to convert raw data
-    // This is a placeholder implementation - actual BMP280 requires complex calibration
     
-    // Convert to proper units
-    F32 pressure = static_cast<F32>(raw.pressure) / 256.0f;  // Convert to Pascals
-    F32 temperature = static_cast<F32>(raw.temperature) / 5120.0f;  // Convert to Celsius
+    // BMP280 Temperature Compensation (from datasheet)
+    // Returns temperature in DegC, resolution is 0.01 DegC
+    I32 adc_T = static_cast<I32>(raw.temperature);
+    I32 var1, var2, t_fine;
+    var1 = ((((adc_T >> 3) - (static_cast<I32>(calib.dig_T1) << 1))) * static_cast<I32>(calib.dig_T2)) >> 11;
+    var2 = (((((adc_T >> 4) - static_cast<I32>(calib.dig_T1)) * ((adc_T >> 4) - static_cast<I32>(calib.dig_T1))) >> 12) * static_cast<I32>(calib.dig_T3)) >> 14;
+    t_fine = var1 + var2;
+    F32 temperature = static_cast<F32>((t_fine * 5 + 128) >> 8) / 100.0f;
+    
+    // BMP280 Pressure Compensation (from datasheet)
+    // Returns pressure in Pa as unsigned 32 bit integer
+    I32 adc_P = static_cast<I32>(raw.pressure);
+    I64 var1_64, var2_64, p_64;
+    var1_64 = static_cast<I64>(t_fine) - 128000;
+    var2_64 = var1_64 * var1_64 * static_cast<I64>(calib.dig_P6);
+    var2_64 = var2_64 + ((var1_64 * static_cast<I64>(calib.dig_P5)) << 17);
+    var2_64 = var2_64 + (static_cast<I64>(calib.dig_P4) << 35);
+    var1_64 = ((var1_64 * var1_64 * static_cast<I64>(calib.dig_P3)) >> 8) + ((var1_64 * static_cast<I64>(calib.dig_P2)) << 12);
+    var1_64 = (((static_cast<I64>(1) << 47) + var1_64)) * static_cast<I64>(calib.dig_P1) >> 33;
+    
+    F32 pressure = 0.0f;
+    if (var1_64 != 0) {
+        p_64 = 1048576 - adc_P;
+        p_64 = (((p_64 << 31) - var2_64) * 3125) / var1_64;
+        var1_64 = (static_cast<I64>(calib.dig_P9) * (p_64 >> 13) * (p_64 >> 13)) >> 25;
+        var2_64 = (static_cast<I64>(calib.dig_P8) * p_64) >> 19;
+        p_64 = ((p_64 + var1_64 + var2_64) >> 8) + (static_cast<I64>(calib.dig_P7) << 4);
+        pressure = static_cast<F32>(p_64) / 256.0f;
+    }
     
     // Calculate altitude using barometric formula
     F32 altitude = calculate_altitude(pressure, seaLevelPressure);
+    
+    printf("[BmpManager] Temperature compensation: raw=%u -> %.2f°C (t_fine=%d)\n", raw.temperature, temperature, t_fine);
+    printf("[BmpManager] Pressure compensation: raw=%u -> %.2f Pa\n", raw.pressure, pressure);
     
     bmpData.setpressure(pressure);
     bmpData.settemperature(temperature);
@@ -227,12 +421,26 @@ F32 BmpManager ::calculate_altitude(F32 pressure, F32 seaLevelPressure) {
     // Barometric formula for altitude calculation
     // altitude = 44330 * (1 - (pressure / seaLevelPressure)^(1/5.255))
     
+    printf("[BmpManager] Calculating altitude: pressure=%.2f Pa, sea_level=%.2f Pa\n", pressure, seaLevelPressure);
+    
     if (seaLevelPressure <= 0.0f || pressure <= 0.0f) {
+        printf("[BmpManager] ERROR: Invalid pressure values for altitude calculation\n");
         return 0.0f;  // Return 0 for invalid inputs
     }
     
     F32 ratio = pressure / seaLevelPressure;
-    F32 altitude = 44330.0f * (1.0f - pow(ratio, 1.0f / 5.255f));
+    if (ratio <= 0.0f) {
+        printf("[BmpManager] ERROR: Invalid pressure ratio for altitude calculation\n");
+        return 0.0f;
+    }
+    
+    // Using standard atmosphere model constants
+    static const F32 STANDARD_ALTITUDE_CONSTANT = 44330.0f;
+    static const F32 PRESSURE_EXPONENT = 1.0f / 5.255f;
+    
+    F32 altitude = STANDARD_ALTITUDE_CONSTANT * (1.0f - pow(ratio, PRESSURE_EXPONENT));
+    
+    printf("[BmpManager] Altitude calculated: %.2f m (ratio=%.4f)\n", altitude, ratio);
     
     return altitude;
 }

--- a/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
@@ -1,0 +1,240 @@
+// ======================================================================
+// \title  BmpManager.cpp
+// \author Generated
+// \brief  cpp file for BmpManager component implementation class
+// ======================================================================
+
+#include "fprime-sensors/Bmp280/Components/BmpManager/BmpManager.hpp"
+#include <cmath>
+
+namespace Bmp280 {
+
+// ----------------------------------------------------------------------
+// Component construction and destruction
+// ----------------------------------------------------------------------
+
+BmpManager ::BmpManager(const char* const compName) : BmpManagerComponentBase(compName), m_state(RESET) {}
+
+BmpManager ::~BmpManager() {}
+
+// ----------------------------------------------------------------------
+// Handler implementations for typed input ports
+// ----------------------------------------------------------------------
+
+void BmpManager ::parameterUpdated(FwPrmIdType id) {
+    Fw::ParamValid isValid = Fw::ParamValid::INVALID;
+    switch (id) {
+        case PARAMID_PRESSURE_OVERSAMPLING: {
+            // Read back the parameter value
+            const PressureOversampling oversampling = this->paramGet_PRESSURE_OVERSAMPLING(isValid);
+            // NOTE: isValid is always VALID in parameterUpdated as it was just properly set
+            FW_ASSERT(isValid == Fw::ParamValid::VALID, static_cast<FwAssertArgType>(isValid));
+            this->log_ACTIVITY_HI_PressureOversamplingUpdated(oversampling);
+            this->m_state = CONFIGURE;
+            break;
+        }
+        case PARAMID_TEMPERATURE_OVERSAMPLING: {
+            // Read back the parameter value
+            const TemperatureOversampling oversampling = this->paramGet_TEMPERATURE_OVERSAMPLING(isValid);
+            // NOTE: isValid is always VALID in parameterUpdated as it was just properly set
+            FW_ASSERT(isValid == Fw::ParamValid::VALID, static_cast<FwAssertArgType>(isValid));
+            this->log_ACTIVITY_HI_TemperatureOversamplingUpdated(oversampling);
+            this->m_state = CONFIGURE;
+            break;
+        }
+        case PARAMID_SEA_LEVEL_PRESSURE: {
+            // Sea level pressure parameter updated - no need to reconfigure device
+            break;
+        }
+        default:
+            FW_ASSERT(0, static_cast<FwAssertArgType>(id));
+            break;
+    }
+}
+
+void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
+    switch (this->m_state) {
+        case RESET:
+            // If reset is successful, move to CHIP_ID_CHECK state
+            if (this->reset()) {
+                this->m_state = CHIP_ID_CHECK;
+            }
+            break;
+        case CHIP_ID_CHECK: {
+            U8 chip_id = 0;
+            if (this->read_chip_id(chip_id)) {
+                if (chip_id == CHIP_ID_VALUE) {
+                    this->m_state = CALIBRATION_READ;
+                } else {
+                    this->m_state = RESET;
+                }
+            } else {
+                this->m_state = RESET;
+            }
+            break;
+        }
+        case CALIBRATION_READ:
+            if (this->read_calibration_data()) {
+                this->m_state = CONFIGURE;
+            } else {
+                this->m_state = RESET;
+            }
+            break;
+        case CONFIGURE:
+            if (this->configure_device()) {
+                this->m_state = RUNNING;
+            } else {
+                this->m_state = RESET;
+            }
+            break;
+        case RUNNING: {
+            U8 data[MEASUREMENT_DATA_LENGTH];
+            U8 registerAddress = PRESSURE_MSB_REGISTER;
+
+            Fw::Buffer writeBuffer(&registerAddress, 1);
+            Fw::Buffer readBuffer(data, MEASUREMENT_DATA_LENGTH);
+            
+            if (this->spi_transfer(writeBuffer, readBuffer)) {
+                RawBmpData raw = this->deserialize_raw_data(readBuffer);
+                
+                // Get sea level pressure parameter
+                Fw::ParamValid paramValid;
+                F32 seaLevelPressure = this->paramGet_SEA_LEVEL_PRESSURE(paramValid);
+                FW_ASSERT(paramValid != Fw::ParamValid::INVALID, static_cast<FwAssertArgType>(paramValid));
+                
+                const Bmp280Data bmpData = this->convert_raw_data(raw, this->m_calibration, seaLevelPressure);
+                this->tlmWrite_Reading(bmpData);
+            } else {
+                this->m_state = RESET;
+            }
+            break;
+        }
+        default:
+            FW_ASSERT(0, this->m_state);
+            break;
+    }
+}
+
+// ----------------------------------------------------------------------
+// Helper functions
+// ----------------------------------------------------------------------
+
+bool BmpManager ::reset() {
+    U8 reset_sequence[] = {RESET_REGISTER, RESET_VALUE};
+    Fw::Buffer writeBuffer(reset_sequence, sizeof(reset_sequence));
+    Fw::Buffer readBuffer;
+    return this->spi_transfer(writeBuffer, readBuffer);
+}
+
+bool BmpManager ::read_chip_id(U8& id) {
+    U8 registerAddress = CHIP_ID_REGISTER;
+    Fw::Buffer writeBuffer(&registerAddress, 1);
+    Fw::Buffer readBuffer(&id, 1);
+    return this->spi_transfer(writeBuffer, readBuffer);
+}
+
+bool BmpManager ::read_calibration_data() {
+    U8 data[CALIB_DATA_LENGTH];
+    U8 registerAddress = CALIB_DATA_REGISTER;
+    Fw::Buffer writeBuffer(&registerAddress, 1);
+    Fw::Buffer readBuffer(data, CALIB_DATA_LENGTH);
+    
+    if (this->spi_transfer(writeBuffer, readBuffer)) {
+        // Parse calibration data from the buffer
+        auto deserializer = readBuffer.getDeserializer();
+        // Implementation would parse calibration coefficients
+        return true;
+    }
+    return false;
+}
+
+bool BmpManager ::configure_device() {
+    Fw::ParamValid paramValid;
+    const PressureOversampling pressureOversampling = this->paramGet_PRESSURE_OVERSAMPLING(paramValid);
+    FW_ASSERT(paramValid != Fw::ParamValid::INVALID, static_cast<FwAssertArgType>(paramValid));
+    const TemperatureOversampling temperatureOversampling = this->paramGet_TEMPERATURE_OVERSAMPLING(paramValid);
+    FW_ASSERT(paramValid != Fw::ParamValid::INVALID, static_cast<FwAssertArgType>(paramValid));
+
+    U8 ctrl_meas_value = static_cast<U8>(temperatureOversampling) | 
+                         static_cast<U8>(pressureOversampling) | 
+                         FORCED_MODE;
+    
+    U8 config_sequence[] = {CTRL_MEAS_REGISTER, ctrl_meas_value};
+    Fw::Buffer writeBuffer(config_sequence, sizeof(config_sequence));
+    Fw::Buffer readBuffer;
+    return this->spi_transfer(writeBuffer, readBuffer);
+}
+
+bool BmpManager ::spi_transfer(Fw::Buffer& writeBuffer, Fw::Buffer& readBuffer) {
+    // For SPI, we need to handle the transaction differently
+    // SPI typically requires a single transfer with combined write/read buffer
+    this->spiReadWrite_out(0, writeBuffer, readBuffer);
+    return true;
+}
+
+BmpManager::RawBmpData BmpManager ::deserialize_raw_data(Fw::Buffer& buffer) {
+    auto deserializer = buffer.getDeserializer();
+    RawBmpData raw;
+    U8 pressure_msb, pressure_lsb, pressure_xlsb;
+    U8 temperature_msb, temperature_lsb, temperature_xlsb;
+    
+    deserializer.deserialize(pressure_msb);
+    deserializer.deserialize(pressure_lsb);
+    deserializer.deserialize(pressure_xlsb);
+    deserializer.deserialize(temperature_msb);
+    deserializer.deserialize(temperature_lsb);
+    deserializer.deserialize(temperature_xlsb);
+    
+    raw.pressure = (static_cast<U32>(pressure_msb) << 12) | 
+                   (static_cast<U32>(pressure_lsb) << 4) | 
+                   (static_cast<U32>(pressure_xlsb) >> 4);
+    
+    raw.temperature = (static_cast<U32>(temperature_msb) << 12) | 
+                      (static_cast<U32>(temperature_lsb) << 4) | 
+                      (static_cast<U32>(temperature_xlsb) >> 4);
+    
+    return raw;
+}
+
+Bmp280Data BmpManager ::convert_raw_data(const RawBmpData& raw, const CalibrationData& calib, F32 seaLevelPressure) {
+    Bmp280Data bmpData;
+    // Implementation would use calibration coefficients to convert raw data
+    // This is a placeholder implementation - actual BMP280 requires complex calibration
+    
+    // Convert to proper units
+    F32 pressure = static_cast<F32>(raw.pressure) / 256.0f;  // Convert to Pascals
+    F32 temperature = static_cast<F32>(raw.temperature) / 5120.0f;  // Convert to Celsius
+    
+    // Calculate altitude using barometric formula
+    F32 altitude = calculate_altitude(pressure, seaLevelPressure);
+    
+    bmpData.setpressure(pressure);
+    bmpData.settemperature(temperature);
+    bmpData.setaltitude(altitude);
+    
+    return bmpData;
+}
+
+U8 BmpManager ::pressure_oversampling_to_register(PressureOversampling oversampling) {
+    return static_cast<U8>(oversampling);
+}
+
+U8 BmpManager ::temperature_oversampling_to_register(TemperatureOversampling oversampling) {
+    return static_cast<U8>(oversampling);
+}
+
+F32 BmpManager ::calculate_altitude(F32 pressure, F32 seaLevelPressure) {
+    // Barometric formula for altitude calculation
+    // altitude = 44330 * (1 - (pressure / seaLevelPressure)^(1/5.255))
+    
+    if (seaLevelPressure <= 0.0f || pressure <= 0.0f) {
+        return 0.0f;  // Return 0 for invalid inputs
+    }
+    
+    F32 ratio = pressure / seaLevelPressure;
+    F32 altitude = 44330.0f * (1.0f - pow(ratio, 1.0f / 5.255f));
+    
+    return altitude;
+}
+
+}  // namespace Bmp280 

--- a/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
@@ -15,7 +15,7 @@ namespace Bmp280 {
 // ----------------------------------------------------------------------
 
 BmpManager ::BmpManager(const char* const compName) : BmpManagerComponentBase(compName), m_state(RESET), m_resetAttempts(0) {
-    printf("[BmpManager] Constructor: Starting in RESET state\n");
+    // printf("[BmpManager] Constructor: Starting in RESET state\n");
 }
 
 BmpManager ::~BmpManager() {}
@@ -34,7 +34,7 @@ void BmpManager ::parameterUpdated(FwPrmIdType id) {
             // NOTE: isValid is always VALID in parameterUpdated as it was just properly set
             FW_ASSERT(isValid == Fw::ParamValid::VALID, static_cast<FwAssertArgType>(isValid));
             this->log_ACTIVITY_HI_PressureOversamplingUpdated(oversampling);
-            printf("[BmpManager] Pressure oversampling updated to %d, transitioning to CONFIGURE\n", static_cast<int>(oversampling.e));
+            // printf("[BmpManager] Pressure oversampling updated to %d, transitioning to CONFIGURE\n", static_cast<int>(oversampling.e));
             this->m_state = CONFIGURE;
             break;
         }
@@ -44,37 +44,37 @@ void BmpManager ::parameterUpdated(FwPrmIdType id) {
             // NOTE: isValid is always VALID in parameterUpdated as it was just properly set
             FW_ASSERT(isValid == Fw::ParamValid::VALID, static_cast<FwAssertArgType>(isValid));
             this->log_ACTIVITY_HI_TemperatureOversamplingUpdated(oversampling);
-            printf("[BmpManager] Temperature oversampling updated to %d, transitioning to CONFIGURE\n", static_cast<int>(oversampling.e));
+            // printf("[BmpManager] Temperature oversampling updated to %d, transitioning to CONFIGURE\n", static_cast<int>(oversampling.e));
             this->m_state = CONFIGURE;
             break;
         }
         case PARAMID_SEA_LEVEL_PRESSURE: {
-            printf("[BmpManager] Sea level pressure parameter updated - no reconfiguration needed\n");
+            // printf("[BmpManager] Sea level pressure parameter updated - no reconfiguration needed\n");
             break;
         }
         default:
-            printf("[BmpManager] ERROR: Unknown parameter ID %d\n", static_cast<int>(id));
+            // printf("[BmpManager] ERROR: Unknown parameter ID %d\n", static_cast<int>(id));
             FW_ASSERT(0, static_cast<FwAssertArgType>(id));
             break;
     }
 }
 
 void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
-    printf("[BmpManager] run_handler called, current state: %d\n", static_cast<int>(m_state));
+    // printf("[BmpManager] run_handler called, current state: %d\n", static_cast<int>(m_state));
     
     switch (this->m_state) {
         case RESET:
-            printf("[BmpManager] RESET state: attempt %d\n", m_resetAttempts);
+            // printf("[BmpManager] RESET state: attempt %d\n", m_resetAttempts);
             // If reset is successful, move to STARTUP_DELAY state
             if (this->reset()) {
-                printf("[BmpManager] Reset command sent successfully, waiting for startup delay\n");
+                // printf("[BmpManager] Reset command sent successfully, waiting for startup delay\n");
                 this->m_state = STARTUP_DELAY;
                 this->m_startupCounter = STARTUP_DELAY_CYCLES;
             } else {
-                printf("[BmpManager] Reset command failed\n");
+                // printf("[BmpManager] Reset command failed\n");
                 m_resetAttempts++;
                 if (m_resetAttempts > MAX_RESET_ATTEMPTS) {
-                    printf("[BmpManager] ERROR: Maximum reset attempts exceeded\n");
+                    // printf("[BmpManager] ERROR: Maximum reset attempts exceeded\n");
                     // Stay in RESET state but log error
                     m_resetAttempts = 0;
                 }
@@ -82,63 +82,63 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
             break;
             
         case STARTUP_DELAY:
-            printf("[BmpManager] STARTUP_DELAY state: %d cycles remaining\n", m_startupCounter);
+            // printf("[BmpManager] STARTUP_DELAY state: %d cycles remaining\n", m_startupCounter);
             m_startupCounter--;
             if (m_startupCounter <= 0) {
-                printf("[BmpManager] Startup delay complete, transitioning to CHIP_ID_CHECK\n");
+                // printf("[BmpManager] Startup delay complete, transitioning to CHIP_ID_CHECK\n");
                 this->m_state = CHIP_ID_CHECK;
             }
             break;
             
         case CHIP_ID_CHECK: {
-            printf("[BmpManager] CHIP_ID_CHECK state\n");
+            // printf("[BmpManager] CHIP_ID_CHECK state\n");
             U8 chip_id = 0;
             if (this->read_chip_id(chip_id)) {
-                printf("[BmpManager] Chip ID read successfully: 0x%02X\n", chip_id);
+                // printf("[BmpManager] Chip ID read successfully: 0x%02X\n", chip_id);
                 if (chip_id == CHIP_ID_VALUE) {
-                    printf("[BmpManager] Chip ID matches expected value (0x%02X), transitioning to CALIBRATION_READ\n", CHIP_ID_VALUE);
+                    // printf("[BmpManager] Chip ID matches expected value (0x%02X), transitioning to CALIBRATION_READ\n", CHIP_ID_VALUE);
                     this->m_state = CALIBRATION_READ;
                 } else {
-                    printf("[BmpManager] ERROR: Chip ID mismatch. Expected 0x%02X, got 0x%02X. Resetting.\n", CHIP_ID_VALUE, chip_id);
+                    // printf("[BmpManager] ERROR: Chip ID mismatch. Expected 0x%02X, got 0x%02X. Resetting.\n", CHIP_ID_VALUE, chip_id);
                     this->m_state = RESET;
                     m_resetAttempts = 0;
                 }
             } else {
-                printf("[BmpManager] ERROR: Failed to read chip ID. Resetting.\n");
+                // printf("[BmpManager] ERROR: Failed to read chip ID. Resetting.\n");
                 this->m_state = RESET;
                 m_resetAttempts = 0;
             }
             break;
         }
         case CALIBRATION_READ:
-            printf("[BmpManager] CALIBRATION_READ state\n");
+            //  printf("[BmpManager] CALIBRATION_READ state\n");
             if (this->read_calibration_data()) {
-                printf("[BmpManager] Calibration data read successfully, transitioning to CONFIGURE\n");
+                // printf("[BmpManager] Calibration data read successfully, transitioning to CONFIGURE\n");
                 this->m_state = CONFIGURE;
             } else {
-                printf("[BmpManager] ERROR: Failed to read calibration data. Resetting.\n");
+                // printf("[BmpManager] ERROR: Failed to read calibration data. Resetting.\n");
                 this->m_state = RESET;
                 m_resetAttempts = 0;
             }
             break;
         case CONFIGURE:
-            printf("[BmpManager] CONFIGURE state\n");
+            // printf("[BmpManager] CONFIGURE state\n");
             if (this->configure_device()) {
-                printf("[BmpManager] Device configured successfully, transitioning to RUNNING\n");
+                // printf("[BmpManager] Device configured successfully, transitioning to RUNNING\n");
                 this->m_state = RUNNING;
             } else {
-                printf("[BmpManager] ERROR: Failed to configure device. Resetting.\n");
+                // printf("[BmpManager] ERROR: Failed to configure device. Resetting.\n");
                 this->m_state = RESET;
                 m_resetAttempts = 0;
             }
             break;
         case RUNNING: {
-            printf("[BmpManager] RUNNING state\n");
+            // printf("[BmpManager] RUNNING state\n");
             
             // Step 1: Check if measurement is ready
             U8 status = 0;
             if (!this->read_status(status)) {
-                printf("[BmpManager] ERROR: Failed to read status register. Resetting.\n");
+                // printf("[BmpManager] ERROR: Failed to read status register. Resetting.\n");
                 this->m_state = RESET;
                 m_resetAttempts = 0;
                 break;
@@ -146,13 +146,13 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
             
             // Check if measurement is in progress (bit 3) or if data is being updated (bit 0)
             if ((status & 0x08) || (status & 0x01)) {
-                printf("[BmpManager] Measurement in progress (status=0x%02X), waiting...\n", status);
+                // printf("[BmpManager] Measurement in progress (status=0x%02X), waiting...\n", status);
                 break; // Wait for next cycle
             }
             
             // Step 2: Trigger a new measurement in forced mode
             if (!this->trigger_measurement()) {
-                printf("[BmpManager] ERROR: Failed to trigger measurement. Resetting.\n");
+                // printf("[BmpManager] ERROR: Failed to trigger measurement. Resetting.\n");
                 this->m_state = RESET;
                 m_resetAttempts = 0;
                 break;
@@ -170,7 +170,7 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
             Fw::Buffer readBuffer(spiData, MEASUREMENT_DATA_LENGTH + 1);
             
             if (this->spi_transfer(writeBuffer, readBuffer)) {
-                printf("[BmpManager] Raw measurement data read successfully\n");
+                // printf("[BmpManager] Raw measurement data read successfully\n");
                 
                 // Create buffer pointing to actual data (skip first byte which is register echo)
                 Fw::Buffer dataBuffer(&readBuffer.getData()[1], MEASUREMENT_DATA_LENGTH);
@@ -194,7 +194,7 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
             break;
         }
         default:
-            printf("[BmpManager] ERROR: Unknown state %d\n", static_cast<int>(m_state));
+            // printf("[BmpManager] ERROR: Unknown state %d\n", static_cast<int>(m_state));
             FW_ASSERT(0, this->m_state);
             break;
     }
@@ -205,18 +205,18 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
 // ----------------------------------------------------------------------
 
 bool BmpManager ::reset() {
-    printf("[BmpManager] Sending reset command (0x%02X -> 0x%02X)\n", RESET_REGISTER, RESET_VALUE);
+    // printf("[BmpManager] Sending reset command (0x%02X -> 0x%02X)\n", RESET_REGISTER, RESET_VALUE);
     // For SPI writes, register address MSB must be 0
     U8 reset_sequence[] = {RESET_REGISTER & 0x7F, RESET_VALUE}; // Clear MSB for write
     Fw::Buffer writeBuffer(reset_sequence, sizeof(reset_sequence));
     Fw::Buffer readBuffer;
     bool success = this->spi_transfer(writeBuffer, readBuffer);
-    printf("[BmpManager] Reset command %s\n", success ? "succeeded" : "failed");
+    // printf("[BmpManager] Reset command %s\n", success ? "succeeded" : "failed");
     return success;
 }
 
 bool BmpManager ::read_chip_id(U8& id) {
-    printf("[BmpManager] Reading chip ID from register 0x%02X\n", CHIP_ID_REGISTER);
+    // printf("[BmpManager] Reading chip ID from register 0x%02X\n", CHIP_ID_REGISTER);
     
     // BMP280 SPI protocol: for reads, MSB must be 1, and we need a 2-byte transaction
     // Byte 0: Register address with MSB=1 (0xD0 | 0x80 = 0xD0, already has MSB set)
@@ -231,16 +231,16 @@ bool BmpManager ::read_chip_id(U8& id) {
     if (success) {
         // The chip ID will be in the second byte of the response
         id = readBuffer.getData()[1];
-        printf("[BmpManager] Chip ID read: 0x%02X\n", id);
+        // printf("[BmpManager] Chip ID read: 0x%02X\n", id);
     } else {
-        printf("[BmpManager] Failed to read chip ID\n");
+        // printf("[BmpManager] Failed to read chip ID\n");
         id = 0;
     }
     return success;
 }
 
 bool BmpManager ::read_status(U8& status) {
-    printf("[BmpManager] Reading status from register 0x%02X\n", STATUS_REGISTER);
+    // printf("[BmpManager] Reading status from register 0x%02X\n", STATUS_REGISTER);
     
     // BMP280 SPI protocol: 2-byte transaction for register read
     U8 spiData[2] = {STATUS_REGISTER | 0x80, 0x00}; // Ensure MSB is set for read
@@ -252,9 +252,9 @@ bool BmpManager ::read_status(U8& status) {
     
     if (success) {
         status = readBuffer.getData()[1];
-        printf("[BmpManager] Status read: 0x%02X\n", status);
+        // printf("[BmpManager] Status read: 0x%02X\n", status);
     } else {
-        printf("[BmpManager] Failed to read status\n");
+        // printf("[BmpManager] Failed to read status\n");
         status = 0;
     }
     
@@ -262,8 +262,8 @@ bool BmpManager ::read_status(U8& status) {
 }
 
 bool BmpManager ::read_calibration_data() {
-    printf("[BmpManager] Reading calibration data from register 0x%02X, length %d bytes\n", 
-           CALIB_DATA_REGISTER, CALIB_DATA_LENGTH);
+    // printf("[BmpManager] Reading calibration data from register 0x%02X, length %d bytes\n", 
+    //        CALIB_DATA_REGISTER, CALIB_DATA_LENGTH);
     
     // BMP280 SPI protocol: for multi-byte read, send register address + read 24 bytes
     // Total transaction: 1 byte register address + 24 bytes data = 25 bytes
@@ -277,7 +277,7 @@ bool BmpManager ::read_calibration_data() {
     Fw::Buffer readBuffer(spiData, CALIB_DATA_LENGTH + 1);
     
     if (this->spi_transfer(writeBuffer, readBuffer)) {
-        printf("[BmpManager] Calibration data read successfully, parsing coefficients\n");
+        // printf("[BmpManager] Calibration data read successfully, parsing coefficients\n");
         
         // Parse calibration data from the buffer (skip first byte which is the register echo)
         // Registers 0x88-0x9F contain 12 calibration coefficients (24 bytes)
@@ -297,11 +297,11 @@ bool BmpManager ::read_calibration_data() {
         m_calibration.dig_P8 = (static_cast<I16>(data[21]) << 8) | data[20];
         m_calibration.dig_P9 = (static_cast<I16>(data[23]) << 8) | data[22];
         
-        printf("[BmpManager] Calibration coefficients:\n");
-        printf("  dig_T1=%u, dig_T2=%d, dig_T3=%d\n", m_calibration.dig_T1, m_calibration.dig_T2, m_calibration.dig_T3);
-        printf("  dig_P1=%u, dig_P2=%d, dig_P3=%d\n", m_calibration.dig_P1, m_calibration.dig_P2, m_calibration.dig_P3);
-        printf("  dig_P4=%d, dig_P5=%d, dig_P6=%d\n", m_calibration.dig_P4, m_calibration.dig_P5, m_calibration.dig_P6);
-        printf("  dig_P7=%d, dig_P8=%d, dig_P9=%d\n", m_calibration.dig_P7, m_calibration.dig_P8, m_calibration.dig_P9);
+        // printf("[BmpManager] Calibration coefficients:\n");
+        // printf("  dig_T1=%u, dig_T2=%d, dig_T3=%d\n", m_calibration.dig_T1, m_calibration.dig_T2, m_calibration.dig_T3);
+        // printf("  dig_P1=%u, dig_P2=%d, dig_P3=%d\n", m_calibration.dig_P1, m_calibration.dig_P2, m_calibration.dig_P3);
+        // printf("  dig_P4=%d, dig_P5=%d, dig_P6=%d\n", m_calibration.dig_P4, m_calibration.dig_P5, m_calibration.dig_P6);
+        // printf("  dig_P7=%d, dig_P8=%d, dig_P9=%d\n", m_calibration.dig_P7, m_calibration.dig_P8, m_calibration.dig_P9);
         
         return true;
     }
@@ -310,7 +310,7 @@ bool BmpManager ::read_calibration_data() {
 }
 
 bool BmpManager ::configure_device() {
-    printf("[BmpManager] Configuring device\n");
+    // printf("[BmpManager] Configuring device\n");
     Fw::ParamValid paramValid;
     const PressureOversampling pressureOversampling = this->paramGet_PRESSURE_OVERSAMPLING(paramValid);
     FW_ASSERT(paramValid != Fw::ParamValid::INVALID, static_cast<FwAssertArgType>(paramValid));
@@ -325,7 +325,7 @@ bool BmpManager ::configure_device() {
                          (static_cast<U8>(pressureOversampling) << 2) | 
                          0x00; // Start in sleep mode first
     
-    printf("[BmpManager] Setting CTRL_MEAS register to 0x%02X (temp_os=%d, press_os=%d, mode=sleep)\n", 
+    //printf("[BmpManager] Setting CTRL_MEAS register to 0x%02X (temp_os=%d, press_os=%d, mode=sleep)\n", 
            ctrl_meas_value, static_cast<int>(temperatureOversampling.e), static_cast<int>(pressureOversampling.e));
     
     // For SPI writes, register address MSB must be 0
@@ -345,16 +345,16 @@ bool BmpManager ::configure_device() {
         Fw::Buffer configWriteBuffer(config_sequence, sizeof(config_sequence));
         Fw::Buffer configReadBuffer;
         
-        printf("[BmpManager] Setting CONFIG register to 0x%02X\n", config_value);
+        // printf("[BmpManager] Setting CONFIG register to 0x%02X\n", config_value);
         success = this->spi_transfer(configWriteBuffer, configReadBuffer);
     }
     
-    printf("[BmpManager] Device configuration %s\n", success ? "succeeded" : "failed");
+    // printf("[BmpManager] Device configuration %s\n", success ? "succeeded" : "failed");
     return success;
 }
 
 bool BmpManager ::trigger_measurement() {
-    printf("[BmpManager] Triggering measurement in forced mode\n");
+    // printf("[BmpManager] Triggering measurement in forced mode\n");
     Fw::ParamValid paramValid;
     const PressureOversampling pressureOversampling = this->paramGet_PRESSURE_OVERSAMPLING(paramValid);
     FW_ASSERT(paramValid != Fw::ParamValid::INVALID, static_cast<FwAssertArgType>(paramValid));
@@ -374,29 +374,29 @@ bool BmpManager ::trigger_measurement() {
 }
 
 bool BmpManager ::spi_transfer(Fw::Buffer& writeBuffer, Fw::Buffer& readBuffer) {
-    printf("[BmpManager] SPI transfer: writing %d bytes, reading %d bytes\n", 
-           writeBuffer.getSize(), readBuffer.getSize());
+    // printf("[BmpManager] SPI transfer: writing %d bytes, reading %d bytes\n", 
+    //        writeBuffer.getSize(), readBuffer.getSize());
     
     // Print write data for debugging
     if (writeBuffer.getSize() > 0) {
-        printf("[BmpManager] Write data: ");
+        // printf("[BmpManager] Write data: ");
         for (U32 i = 0; i < writeBuffer.getSize(); i++) {
-            printf("0x%02X ", writeBuffer.getData()[i]);
+            // printf("0x%02X ", writeBuffer.getData()[i]);
         }
-        printf("\n");
+        // printf("\n");
     }
     
     // Perform the SPI transfer
     this->spiReadWrite_out(0, writeBuffer, readBuffer);
     
     // Print read data for debugging
-    if (readBuffer.getSize() > 0) {
-        printf("[BmpManager] Read data: ");
-        for (U32 i = 0; i < readBuffer.getSize(); i++) {
-            printf("0x%02X ", readBuffer.getData()[i]);
-        }
-        printf("\n");
-    }
+    // if (readBuffer.getSize() > 0) {
+    //     printf("[BmpManager] Read data: ");
+    //     for (U32 i = 0; i < readBuffer.getSize(); i++) {
+    //         printf("0x%02X ", readBuffer.getData()[i]);
+    //     }
+    //     printf("\n");
+    // }
     
     // TODO: In a real implementation, we should check for SPI errors
     // For now, we assume success but this is where error detection should be added
@@ -464,8 +464,8 @@ Bmp280Data BmpManager ::convert_raw_data(const RawBmpData& raw, const Calibratio
     // Calculate altitude using barometric formula
     F32 altitude = calculate_altitude(pressure, seaLevelPressure);
     
-    printf("[BmpManager] Temperature compensation: raw=%u -> %.2f°C (t_fine=%d)\n", raw.temperature, temperature, t_fine);
-    printf("[BmpManager] Pressure compensation: raw=%u -> %.2f Pa\n", raw.pressure, pressure);
+    // printf("[BmpManager] Temperature compensation: raw=%u -> %.2f°C (t_fine=%d)\n", raw.temperature, temperature, t_fine);
+    // printf("[BmpManager] Pressure compensation: raw=%u -> %.2f Pa\n", raw.pressure, pressure);
     
     bmpData.setpressure(pressure);
     bmpData.settemperature(temperature);
@@ -486,16 +486,16 @@ F32 BmpManager ::calculate_altitude(F32 pressure, F32 seaLevelPressure) {
     // Barometric formula for altitude calculation
     // altitude = 44330 * (1 - (pressure / seaLevelPressure)^(1/5.255))
     
-    printf("[BmpManager] Calculating altitude: pressure=%.2f Pa, sea_level=%.2f Pa\n", pressure, seaLevelPressure);
+    // printf("[BmpManager] Calculating altitude: pressure=%.2f Pa, sea_level=%.2f Pa\n", pressure, seaLevelPressure);
     
     if (seaLevelPressure <= 0.0f || pressure <= 0.0f) {
-        printf("[BmpManager] ERROR: Invalid pressure values for altitude calculation\n");
+        // printf("[BmpManager] ERROR: Invalid pressure values for altitude calculation\n");
         return 0.0f;  // Return 0 for invalid inputs
     }
     
     F32 ratio = pressure / seaLevelPressure;
     if (ratio <= 0.0f) {
-        printf("[BmpManager] ERROR: Invalid pressure ratio for altitude calculation\n");
+        // printf("[BmpManager] ERROR: Invalid pressure ratio for altitude calculation\n");
         return 0.0f;
     }
     
@@ -505,7 +505,7 @@ F32 BmpManager ::calculate_altitude(F32 pressure, F32 seaLevelPressure) {
     
     F32 altitude = STANDARD_ALTITUDE_CONSTANT * (1.0f - pow(ratio, PRESSURE_EXPONENT));
     
-    printf("[BmpManager] Altitude calculated: %.2f m (ratio=%.4f)\n", altitude, ratio);
+    // printf("[BmpManager] Altitude calculated: %.2f m (ratio=%.4f)\n", altitude, ratio);
     
     return altitude;
 }

--- a/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
@@ -58,23 +58,18 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
                 this->log_WARNING_HI_DeviceFailure();
             }
             break;
-            
+
         case STARTUP_DELAY:
             this->m_startupCounter--;
             if (this->m_startupCounter <= 0) {
                 this->m_state = CHIP_ID_CHECK;
             }
             break;
-            
+
         case CHIP_ID_CHECK: {
             U8 chip_id = 0;
-            if (this->read_chip_id(chip_id)) {
-                if (chip_id == CHIP_ID_VALUE) {
-                    this->m_state = CALIBRATION_READ;
-                } else {
-                    this->m_state = RESET;
-                    this->log_WARNING_HI_ChipIdCheckFailure();
-                }
+            if (this->read_chip_id(chip_id) && chip_id == CHIP_ID_VALUE) {
+                this->m_state = CALIBRATION_READ;
             } else {
                 this->m_state = RESET;
                 this->log_WARNING_HI_ChipIdCheckFailure();
@@ -99,44 +94,40 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
             break;
         case RUNNING: {
             // Reset throttles for logged events
-            this->log_WARNING_HI_DeviceFailure_ThrottleClear(); // Clear throttle for Device Failure event
-            this->log_WARNING_HI_ChipIdCheckFailure_ThrottleClear(); // Clear throttle for Chip ID Check Failure event
-            this->log_WARNING_HI_CalibrationFailure_ThrottleClear(); // Clear throttle for Data Calibration Failure event
-            this->log_WARNING_HI_DeviceConfigureFailure_ThrottleClear(); // Clear throttle for Device Configure Failure  event
-            this->log_WARNING_HI_MeasurementTriggerFailure_ThrottleClear(); // Clear throttle for Measurement Trigger Failure event
-            this->log_WARNING_HI_SpiTransferFailure_ThrottleClear(); // Clear throttle for SPI Transfer Failure event
-
-
-            
+            this->log_WARNING_HI_DeviceFailure_ThrottleClear();       // Clear throttle for Device Failure event
+            this->log_WARNING_HI_ChipIdCheckFailure_ThrottleClear();  // Clear throttle for Chip ID Check Failure event
+            this->log_WARNING_HI_CalibrationFailure_ThrottleClear();  // Clear throttle for Data Calibration Failure
+                                                                      // event
+            this->log_WARNING_HI_DeviceConfigureFailure_ThrottleClear();  // Clear throttle for Device Configure Failure
+                                                                          // event
             // Step 1: Check if measurement is ready
             U8 status = 0;
             if (!this->read_status(status)) {
                 this->m_state = RESET;
                 break;
             }
-            
+
             // Check if measurement is in progress (bit 3) or if data is being updated (bit 0)
             if ((status & 0x08) || (status & 0x01)) {
-                break; // Wait for next cycle
+                break;  // Wait for next cycle
             }
-            
+
             // Step 2: Trigger a new measurement in forced mode
             if (!this->trigger_measurement()) {
                 this->m_state = RESET;
                 this->log_WARNING_HI_MeasurementTriggerFailure();
                 break;
             }
-            
+
             // Step 3: Read measurement data
             // BMP280 SPI protocol: read 6 bytes starting from PRESSURE_MSB_REGISTER
             U8 spiData[MEASUREMENT_DATA_LENGTH + 1] = {0};
-            spiData[0] = PRESSURE_MSB_REGISTER | 0x80; // Register address with MSB=1 for read
+            spiData[0] = PRESSURE_MSB_REGISTER | 0x80;  // Register address with MSB=1 for read
 
             Fw::Buffer writeBuffer(spiData, MEASUREMENT_DATA_LENGTH + 1);
             Fw::Buffer readBuffer(spiData, MEASUREMENT_DATA_LENGTH + 1);
-            
+
             if (this->spi_transfer(writeBuffer, readBuffer)) {
-                
                 // Skip first byte (register echo) and deserialize measurement data directly
                 U8* dataPtr = &readBuffer.getData()[1];
                 Fw::Buffer dataBuffer(dataPtr, MEASUREMENT_DATA_LENGTH);
@@ -146,13 +137,18 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
                 Fw::ParamValid paramValid;
                 F32 seaLevelPressure = this->paramGet_SEA_LEVEL_PRESSURE(paramValid);
                 FW_ASSERT(paramValid != Fw::ParamValid::INVALID, static_cast<FwAssertArgType>(paramValid));
-                
+
                 const Bmp280Data bmpData = this->convert_raw_data(raw, this->m_calibration, seaLevelPressure);
 
                 this->tlmWrite_Reading(bmpData);
+
+                this->log_WARNING_HI_MeasurementTriggerFailure_ThrottleClear();  // Clear throttle for Measurement
+                                                                                 // Trigger Failure event
+                this->log_WARNING_HI_DeviceReadFailure_ThrottleClear();  // Clear throttle for read Failure event
+
             } else {
                 this->m_state = RESET;
-                this->log_WARNING_HI_SpiTransferFailure();
+                this->log_WARNING_HI_DeviceReadFailure();
             }
             break;
         }
@@ -167,7 +163,7 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
 // ----------------------------------------------------------------------
 
 bool BmpManager ::reset() {
-    U8 reset_sequence[] = {RESET_REGISTER & 0x7F, RESET_VALUE}; // Clear MSB for write
+    U8 reset_sequence[] = {RESET_REGISTER & 0x7F, RESET_VALUE};  // Clear MSB for write
     Fw::Buffer writeBuffer(reset_sequence, sizeof(reset_sequence));
     Fw::Buffer readBuffer;
     bool success = this->spi_transfer(writeBuffer, readBuffer);
@@ -175,14 +171,13 @@ bool BmpManager ::reset() {
 }
 
 bool BmpManager ::read_chip_id(U8& id) {
-    
-    U8 spiData[2] = {CHIP_ID_REGISTER | 0x80, 0x00}; // Ensure MSB is set for read
-    
+    U8 spiData[2] = {CHIP_ID_REGISTER | 0x80, 0x00};  // Ensure MSB is set for read
+
     Fw::Buffer writeBuffer(spiData, 2);
-    Fw::Buffer readBuffer(spiData, 2); // Reuse same buffer for read
-    
+    Fw::Buffer readBuffer(spiData, 2);  // Reuse same buffer for read
+
     bool success = this->spi_transfer(writeBuffer, readBuffer);
-    
+
     if (success) {
         id = readBuffer.getData()[1];
     } else {
@@ -192,42 +187,39 @@ bool BmpManager ::read_chip_id(U8& id) {
 }
 
 bool BmpManager ::read_status(U8& status) {
-    
-    U8 spiData[2] = {STATUS_REGISTER | 0x80, 0x00}; // Ensure MSB is set for read
-    
+    U8 spiData[2] = {STATUS_REGISTER | 0x80, 0x00};  // Ensure MSB is set for read
+
     Fw::Buffer writeBuffer(spiData, 2);
     Fw::Buffer readBuffer(spiData, 2);
-    
+
     bool success = this->spi_transfer(writeBuffer, readBuffer);
-    
+
     if (success) {
         status = readBuffer.getData()[1];
     } else {
         status = 0;
     }
-    
+
     return success;
 }
 
 bool BmpManager ::read_calibration_data() {
-    
     U8 spiData[CALIB_DATA_LENGTH + 1];
-    spiData[0] = CALIB_DATA_REGISTER | 0x80; // Register address with MSB=1 for read
+    spiData[0] = CALIB_DATA_REGISTER | 0x80;  // Register address with MSB=1 for read
     for (U32 i = 1; i <= CALIB_DATA_LENGTH; i++) {
-        spiData[i] = 0x00; // Dummy bytes that will be filled with calibration data
+        spiData[i] = 0x00;  // Dummy bytes that will be filled with calibration data
     }
-    
+
     Fw::Buffer writeBuffer(spiData, CALIB_DATA_LENGTH + 1);
     Fw::Buffer readBuffer(spiData, CALIB_DATA_LENGTH + 1);
-    
+
     if (this->spi_transfer(writeBuffer, readBuffer)) {
-        
         U8* data = &readBuffer.getData()[1];
-        
+
         m_calibration.dig_T1 = (static_cast<U16>(data[1]) << 8) | data[0];
         m_calibration.dig_T2 = (static_cast<I16>(data[3]) << 8) | data[2];
         m_calibration.dig_T3 = (static_cast<I16>(data[5]) << 8) | data[4];
-        
+
         m_calibration.dig_P1 = (static_cast<U16>(data[7]) << 8) | data[6];
         m_calibration.dig_P2 = (static_cast<I16>(data[9]) << 8) | data[8];
         m_calibration.dig_P3 = (static_cast<I16>(data[11]) << 8) | data[10];
@@ -237,7 +229,7 @@ bool BmpManager ::read_calibration_data() {
         m_calibration.dig_P7 = (static_cast<I16>(data[19]) << 8) | data[18];
         m_calibration.dig_P8 = (static_cast<I16>(data[21]) << 8) | data[20];
         m_calibration.dig_P9 = (static_cast<I16>(data[23]) << 8) | data[22];
-        
+
         return true;
     }
     return false;
@@ -251,29 +243,28 @@ bool BmpManager ::configure_device() {
     FW_ASSERT(paramValid != Fw::ParamValid::INVALID, static_cast<FwAssertArgType>(paramValid));
 
     // CTRL_MEAS register (0xF4) format:
-    // bits 7:5 = osrs_t (temperature oversampling)  
+    // bits 7:5 = osrs_t (temperature oversampling)
     // bits 4:2 = osrs_p (pressure oversampling)
     // bits 1:0 = mode (00=sleep, 01=forced, 11=normal)
-    U8 ctrl_meas_value = (static_cast<U8>(temperatureOversampling) << 5) | 
-                         (static_cast<U8>(pressureOversampling) << 2) | 
-                         0x00; // Start in sleep mode first
-    
-    U8 config_sequence[] = {CTRL_MEAS_REGISTER & 0x7F, ctrl_meas_value}; // Clear MSB for write
+    U8 ctrl_meas_value = (static_cast<U8>(temperatureOversampling) << 5) |
+                         (static_cast<U8>(pressureOversampling) << 2) | 0x00;  // Start in sleep mode first
+
+    U8 config_sequence[] = {CTRL_MEAS_REGISTER & 0x7F, ctrl_meas_value};  // Clear MSB for write
     Fw::Buffer writeBuffer(config_sequence, sizeof(config_sequence));
     Fw::Buffer readBuffer;
-    
+
     bool success = this->spi_transfer(writeBuffer, readBuffer);
-    
+
     if (success) {
-        U8 config_value = 0x00; // No IIR filter, 4-wire SPI
-        U8 config_sequence[] = {CONFIG_REGISTER & 0x7F, config_value}; // Clear MSB for write
+        U8 config_value = 0x00;                                         // No IIR filter, 4-wire SPI
+        U8 config_sequence[] = {CONFIG_REGISTER & 0x7F, config_value};  // Clear MSB for write
         Fw::Buffer configWriteBuffer(config_sequence, sizeof(config_sequence));
         Fw::Buffer configReadBuffer;
-        
+
         success = this->spi_transfer(configWriteBuffer, configReadBuffer);
     }
-    
-    return success; 
+
+    return success;
 }
 
 bool BmpManager ::trigger_measurement() {
@@ -284,12 +275,11 @@ bool BmpManager ::trigger_measurement() {
     FW_ASSERT(paramValid != Fw::ParamValid::INVALID, static_cast<FwAssertArgType>(paramValid));
 
     // Set device to forced mode to trigger a measurement
-    U8 ctrl_meas_value = (static_cast<U8>(temperatureOversampling) << 5) | 
-                         (static_cast<U8>(pressureOversampling) << 2) | 
-                         FORCED_MODE;
-    
+    U8 ctrl_meas_value =
+        (static_cast<U8>(temperatureOversampling) << 5) | (static_cast<U8>(pressureOversampling) << 2) | FORCED_MODE;
+
     // For SPI writes, register address MSB must be 0
-    U8 config_sequence[] = {CTRL_MEAS_REGISTER & 0x7F, ctrl_meas_value}; // Clear MSB for write
+    U8 config_sequence[] = {CTRL_MEAS_REGISTER & 0x7F, ctrl_meas_value};  // Clear MSB for write
     Fw::Buffer writeBuffer(config_sequence, sizeof(config_sequence));
     Fw::Buffer readBuffer;
     return this->spi_transfer(writeBuffer, readBuffer);
@@ -297,17 +287,17 @@ bool BmpManager ::trigger_measurement() {
 
 bool BmpManager ::spi_transfer(Fw::Buffer& writeBuffer, Fw::Buffer& readBuffer) {
     // Validate buffer sizes
-    FW_ASSERT(writeBuffer.getSize() == 0); 
+    FW_ASSERT(writeBuffer.getSize() == 0);
 
-    FW_ASSERT(readBuffer.getSize() == 0); 
+    FW_ASSERT(readBuffer.getSize() == 0);
 
-    FW_ASSERT(writeBuffer.getSize() == readBuffer.getSize()); 
-    
+    FW_ASSERT(writeBuffer.getSize() == readBuffer.getSize());
+
     // Perform the SPI transfer
     // Note: spiReadWrite_out calls the underlying SPI driver
     this->spiReadWrite_out(0, writeBuffer, readBuffer);
-    
-    // Linux SPI driver logs warnings internally if ioctl fails 
+
+    // Linux SPI driver logs warnings internally if ioctl fails
     return true;
 }
 
@@ -316,37 +306,38 @@ BmpManager::RawBmpData BmpManager ::deserialize_raw_data(Fw::Buffer& buffer) {
     RawBmpData raw;
     U8 pressure_msb, pressure_lsb, pressure_xlsb;
     U8 temperature_msb, temperature_lsb, temperature_xlsb;
-    
+
     deserializer.deserialize(pressure_msb);
     deserializer.deserialize(pressure_lsb);
     deserializer.deserialize(pressure_xlsb);
     deserializer.deserialize(temperature_msb);
     deserializer.deserialize(temperature_lsb);
     deserializer.deserialize(temperature_xlsb);
-    
-    raw.pressure = (static_cast<U32>(pressure_msb) << 12) | 
-                   (static_cast<U32>(pressure_lsb) << 4) | 
+
+    raw.pressure = (static_cast<U32>(pressure_msb) << 12) | (static_cast<U32>(pressure_lsb) << 4) |
                    (static_cast<U32>(pressure_xlsb) >> 4);
-    
-    raw.temperature = (static_cast<U32>(temperature_msb) << 12) | 
-                      (static_cast<U32>(temperature_lsb) << 4) | 
+
+    raw.temperature = (static_cast<U32>(temperature_msb) << 12) | (static_cast<U32>(temperature_lsb) << 4) |
                       (static_cast<U32>(temperature_xlsb) >> 4);
-    
+
     return raw;
 }
 
 Bmp280Data BmpManager ::convert_raw_data(const RawBmpData& raw, const CalibrationData& calib, F32 seaLevelPressure) {
     Bmp280Data bmpData;
-    
+
     // BMP280 Temperature Compensation (from datasheet)
     // Returns temperature in DegC, resolution is 0.01 DegC
     I32 adc_T = static_cast<I32>(raw.temperature);
     I32 var1, var2, t_fine;
     var1 = ((((adc_T >> 3) - (static_cast<I32>(calib.dig_T1) << 1))) * static_cast<I32>(calib.dig_T2)) >> 11;
-    var2 = (((((adc_T >> 4) - static_cast<I32>(calib.dig_T1)) * ((adc_T >> 4) - static_cast<I32>(calib.dig_T1))) >> 12) * static_cast<I32>(calib.dig_T3)) >> 14;
+    var2 =
+        (((((adc_T >> 4) - static_cast<I32>(calib.dig_T1)) * ((adc_T >> 4) - static_cast<I32>(calib.dig_T1))) >> 12) *
+         static_cast<I32>(calib.dig_T3)) >>
+        14;
     t_fine = var1 + var2;
     F32 temperature = static_cast<F32>((t_fine * 5 + 128) >> 8) / 100.0f;
-    
+
     // BMP280 Pressure Compensation (from datasheet)
     // Returns pressure in Pa as unsigned 32 bit integer
     I32 adc_P = static_cast<I32>(raw.pressure);
@@ -355,9 +346,10 @@ Bmp280Data BmpManager ::convert_raw_data(const RawBmpData& raw, const Calibratio
     var2_64 = var1_64 * var1_64 * static_cast<I64>(calib.dig_P6);
     var2_64 = var2_64 + ((var1_64 * static_cast<I64>(calib.dig_P5)) << 17);
     var2_64 = var2_64 + (static_cast<I64>(calib.dig_P4) << 35);
-    var1_64 = ((var1_64 * var1_64 * static_cast<I64>(calib.dig_P3)) >> 8) + ((var1_64 * static_cast<I64>(calib.dig_P2)) << 12);
+    var1_64 = ((var1_64 * var1_64 * static_cast<I64>(calib.dig_P3)) >> 8) +
+              ((var1_64 * static_cast<I64>(calib.dig_P2)) << 12);
     var1_64 = (((static_cast<I64>(1) << 47) + var1_64)) * static_cast<I64>(calib.dig_P1) >> 33;
-    
+
     F32 pressure = 0.0f;
     if (var1_64 != 0) {
         p_64 = 1048576 - adc_P;
@@ -367,14 +359,14 @@ Bmp280Data BmpManager ::convert_raw_data(const RawBmpData& raw, const Calibratio
         p_64 = ((p_64 + var1_64 + var2_64) >> 8) + (static_cast<I64>(calib.dig_P7) << 4);
         pressure = static_cast<F32>(p_64) / 256.0f;
     }
-    
+
     // Calculate altitude using barometric formula
     F32 altitude = calculate_altitude(pressure, seaLevelPressure);
-    
+
     bmpData.setpressure(pressure);
     bmpData.settemperature(temperature);
     bmpData.setaltitude(altitude);
-    
+
     return bmpData;
 }
 
@@ -382,21 +374,21 @@ F32 BmpManager ::calculate_altitude(F32 pressure, F32 seaLevelPressure) {
     if (seaLevelPressure <= 0.0f || pressure <= 0.0f) {
         return 0.0f;  // Return 0 for invalid inputs
     }
-    
+
     F32 ratio = pressure / seaLevelPressure;
     if (ratio <= 0.0f) {
         return 0.0f;
     }
-    
+
     // Using standard atmosphere model constants
     // Barometric formula for altitude calculation
     // altitude = 44330 * (1 - (pressure / seaLevelPressure)^(1/5.255))
     static const F32 STANDARD_ALTITUDE_CONSTANT = 44330.0f;
     static const F32 PRESSURE_EXPONENT = 1.0f / 5.255f;
-    
+
     F32 altitude = STANDARD_ALTITUDE_CONSTANT * (1.0f - pow(ratio, PRESSURE_EXPONENT));
-    
+
     return altitude;
 }
 
-}  // namespace Bmp280 
+}  // namespace Bmp280

--- a/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
@@ -159,15 +159,22 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
             }
             
             // Step 3: Read measurement data
-            U8 data[MEASUREMENT_DATA_LENGTH];
-            U8 registerAddress = PRESSURE_MSB_REGISTER;
+            // BMP280 SPI protocol: read 6 bytes starting from PRESSURE_MSB_REGISTER
+            U8 spiData[MEASUREMENT_DATA_LENGTH + 1];
+            spiData[0] = PRESSURE_MSB_REGISTER | 0x80; // Register address with MSB=1 for read
+            for (int i = 1; i <= MEASUREMENT_DATA_LENGTH; i++) {
+                spiData[i] = 0x00; // Dummy bytes
+            }
 
-            Fw::Buffer writeBuffer(&registerAddress, 1);
-            Fw::Buffer readBuffer(data, MEASUREMENT_DATA_LENGTH);
+            Fw::Buffer writeBuffer(spiData, MEASUREMENT_DATA_LENGTH + 1);
+            Fw::Buffer readBuffer(spiData, MEASUREMENT_DATA_LENGTH + 1);
             
             if (this->spi_transfer(writeBuffer, readBuffer)) {
                 printf("[BmpManager] Raw measurement data read successfully\n");
-                RawBmpData raw = this->deserialize_raw_data(readBuffer);
+                
+                // Create buffer pointing to actual data (skip first byte which is register echo)
+                Fw::Buffer dataBuffer(&readBuffer.getData()[1], MEASUREMENT_DATA_LENGTH);
+                RawBmpData raw = this->deserialize_raw_data(dataBuffer);
                 printf("[BmpManager] Raw pressure: %u, Raw temperature: %u\n", raw.pressure, raw.temperature);
                 
                 // Get sea level pressure parameter
@@ -199,7 +206,8 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
 
 bool BmpManager ::reset() {
     printf("[BmpManager] Sending reset command (0x%02X -> 0x%02X)\n", RESET_REGISTER, RESET_VALUE);
-    U8 reset_sequence[] = {RESET_REGISTER, RESET_VALUE};
+    // For SPI writes, register address MSB must be 0
+    U8 reset_sequence[] = {RESET_REGISTER & 0x7F, RESET_VALUE}; // Clear MSB for write
     Fw::Buffer writeBuffer(reset_sequence, sizeof(reset_sequence));
     Fw::Buffer readBuffer;
     bool success = this->spi_transfer(writeBuffer, readBuffer);
@@ -209,37 +217,92 @@ bool BmpManager ::reset() {
 
 bool BmpManager ::read_chip_id(U8& id) {
     printf("[BmpManager] Reading chip ID from register 0x%02X\n", CHIP_ID_REGISTER);
-    U8 registerAddress = CHIP_ID_REGISTER;
-    Fw::Buffer writeBuffer(&registerAddress, 1);
-    Fw::Buffer readBuffer(&id, 1);
+    
+    // BMP280 SPI protocol: for reads, MSB must be 1, and we need a 2-byte transaction
+    // Byte 0: Register address with MSB=1 (0xD0 | 0x80 = 0xD0, already has MSB set)
+    // Byte 1: Dummy byte (will be replaced with register value)
+    U8 spiData[2] = {CHIP_ID_REGISTER | 0x80, 0x00}; // Ensure MSB is set for read
+    
+    Fw::Buffer writeBuffer(spiData, 2);
+    Fw::Buffer readBuffer(spiData, 2); // Reuse same buffer for read
+    
     bool success = this->spi_transfer(writeBuffer, readBuffer);
+    
     if (success) {
+        // The chip ID will be in the second byte of the response
+        id = readBuffer.getData()[1];
         printf("[BmpManager] Chip ID read: 0x%02X\n", id);
     } else {
         printf("[BmpManager] Failed to read chip ID\n");
+        id = 0;
     }
     return success;
 }
 
 bool BmpManager ::read_status(U8& status) {
-    U8 registerAddress = STATUS_REGISTER;
-    Fw::Buffer writeBuffer(&registerAddress, 1);
-    Fw::Buffer readBuffer(&status, 1);
-    return this->spi_transfer(writeBuffer, readBuffer);
+    printf("[BmpManager] Reading status from register 0x%02X\n", STATUS_REGISTER);
+    
+    // BMP280 SPI protocol: 2-byte transaction for register read
+    U8 spiData[2] = {STATUS_REGISTER | 0x80, 0x00}; // Ensure MSB is set for read
+    
+    Fw::Buffer writeBuffer(spiData, 2);
+    Fw::Buffer readBuffer(spiData, 2);
+    
+    bool success = this->spi_transfer(writeBuffer, readBuffer);
+    
+    if (success) {
+        status = readBuffer.getData()[1];
+        printf("[BmpManager] Status read: 0x%02X\n", status);
+    } else {
+        printf("[BmpManager] Failed to read status\n");
+        status = 0;
+    }
+    
+    return success;
 }
 
 bool BmpManager ::read_calibration_data() {
     printf("[BmpManager] Reading calibration data from register 0x%02X, length %d bytes\n", 
            CALIB_DATA_REGISTER, CALIB_DATA_LENGTH);
-    U8 data[CALIB_DATA_LENGTH];
-    U8 registerAddress = CALIB_DATA_REGISTER;
-    Fw::Buffer writeBuffer(&registerAddress, 1);
-    Fw::Buffer readBuffer(data, CALIB_DATA_LENGTH);
+    
+    // BMP280 SPI protocol: for multi-byte read, send register address + read 24 bytes
+    // Total transaction: 1 byte register address + 24 bytes data = 25 bytes
+    U8 spiData[CALIB_DATA_LENGTH + 1];
+    spiData[0] = CALIB_DATA_REGISTER | 0x80; // Register address with MSB=1 for read
+    for (int i = 1; i <= CALIB_DATA_LENGTH; i++) {
+        spiData[i] = 0x00; // Dummy bytes that will be filled with calibration data
+    }
+    
+    Fw::Buffer writeBuffer(spiData, CALIB_DATA_LENGTH + 1);
+    Fw::Buffer readBuffer(spiData, CALIB_DATA_LENGTH + 1);
     
     if (this->spi_transfer(writeBuffer, readBuffer)) {
-        // Parse calibration data from the buffer
-        auto deserializer = readBuffer.getDeserializer();
-        // Implementation would parse calibration coefficients
+        printf("[BmpManager] Calibration data read successfully, parsing coefficients\n");
+        
+        // Parse calibration data from the buffer (skip first byte which is the register echo)
+        // Registers 0x88-0x9F contain 12 calibration coefficients (24 bytes)
+        U8* data = &readBuffer.getData()[1]; // Skip the first byte (register address echo)
+        
+        m_calibration.dig_T1 = (static_cast<U16>(data[1]) << 8) | data[0];
+        m_calibration.dig_T2 = (static_cast<I16>(data[3]) << 8) | data[2];
+        m_calibration.dig_T3 = (static_cast<I16>(data[5]) << 8) | data[4];
+        
+        m_calibration.dig_P1 = (static_cast<U16>(data[7]) << 8) | data[6];
+        m_calibration.dig_P2 = (static_cast<I16>(data[9]) << 8) | data[8];
+        m_calibration.dig_P3 = (static_cast<I16>(data[11]) << 8) | data[10];
+        m_calibration.dig_P4 = (static_cast<I16>(data[13]) << 8) | data[12];
+        m_calibration.dig_P5 = (static_cast<I16>(data[15]) << 8) | data[14];
+        m_calibration.dig_P6 = (static_cast<I16>(data[17]) << 8) | data[16];
+        m_calibration.dig_P7 = (static_cast<I16>(data[19]) << 8) | data[18];
+        m_calibration.dig_P8 = (static_cast<I16>(data[21]) << 8) | data[20];
+        m_calibration.dig_P9 = (static_cast<I16>(data[23]) << 8) | data[22];
+        
+        printf("[BmpManager] Calibration coefficients:\n");
+        printf("  dig_T1=%u, dig_T2=%d, dig_T3=%d\n", m_calibration.dig_T1, m_calibration.dig_T2, m_calibration.dig_T3);
+        printf("  dig_P1=%u, dig_P2=%d, dig_P3=%d\n", m_calibration.dig_P1, m_calibration.dig_P2, m_calibration.dig_P3);
+        printf("  dig_P4=%d, dig_P5=%d, dig_P6=%d\n", m_calibration.dig_P4, m_calibration.dig_P5, m_calibration.dig_P6);
+        printf("  dig_P7=%d, dig_P8=%d, dig_P9=%d\n", m_calibration.dig_P7, m_calibration.dig_P8, m_calibration.dig_P9);
+        
         return true;
     }
     printf("[BmpManager] Failed to read calibration data\n");
@@ -265,7 +328,8 @@ bool BmpManager ::configure_device() {
     printf("[BmpManager] Setting CTRL_MEAS register to 0x%02X (temp_os=%d, press_os=%d, mode=sleep)\n", 
            ctrl_meas_value, static_cast<int>(temperatureOversampling.e), static_cast<int>(pressureOversampling.e));
     
-    U8 config_sequence[] = {CTRL_MEAS_REGISTER, ctrl_meas_value};
+    // For SPI writes, register address MSB must be 0
+    U8 config_sequence[] = {CTRL_MEAS_REGISTER & 0x7F, ctrl_meas_value}; // Clear MSB for write
     Fw::Buffer writeBuffer(config_sequence, sizeof(config_sequence));
     Fw::Buffer readBuffer;
     
@@ -277,7 +341,7 @@ bool BmpManager ::configure_device() {
         // bits 4:2 = filter (IIR filter coefficient)
         // bit 0 = spi3w_en (3-wire SPI enable)
         U8 config_value = 0x00; // No IIR filter, 4-wire SPI
-        U8 config_sequence[] = {CONFIG_REGISTER, config_value};
+        U8 config_sequence[] = {CONFIG_REGISTER & 0x7F, config_value}; // Clear MSB for write
         Fw::Buffer configWriteBuffer(config_sequence, sizeof(config_sequence));
         Fw::Buffer configReadBuffer;
         
@@ -302,7 +366,8 @@ bool BmpManager ::trigger_measurement() {
                          (static_cast<U8>(pressureOversampling) << 2) | 
                          FORCED_MODE;
     
-    U8 config_sequence[] = {CTRL_MEAS_REGISTER, ctrl_meas_value};
+    // For SPI writes, register address MSB must be 0
+    U8 config_sequence[] = {CTRL_MEAS_REGISTER & 0x7F, ctrl_meas_value}; // Clear MSB for write
     Fw::Buffer writeBuffer(config_sequence, sizeof(config_sequence));
     Fw::Buffer readBuffer;
     return this->spi_transfer(writeBuffer, readBuffer);

--- a/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
@@ -260,7 +260,7 @@ bool BmpManager ::configure_device() {
         U8 config_value = 0x00;                                         // No IIR filter, 4-wire SPI
         U8 config_sequence[] = {CONFIG_REGISTER & 0x7F, config_value};  // Clear MSB for write
         Fw::Buffer configWriteBuffer(config_sequence, sizeof(config_sequence));
-        Fw::Buffer configReadBuffer;
+        Fw::Buffer configReadBuffer(config_sequence, sizeof(config_sequence));
 
         success = this->spi_transfer(configWriteBuffer, configReadBuffer);
     }

--- a/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
@@ -58,7 +58,7 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
                 m_resetAttempts++;
                 this->log_WARNING_HI_DeviceResetFailed(m_resetAttempts);
                 if (m_resetAttempts > MAX_RESET_ATTEMPTS) {
-                    this->log_FATAL_DeviceFailure();
+                    this->log_WARNING_HI_DeviceFailure();
                     m_resetAttempts = 0;
                 }
             }

--- a/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
@@ -326,7 +326,7 @@ bool BmpManager ::configure_device() {
                          0x00; // Start in sleep mode first
     
     //printf("[BmpManager] Setting CTRL_MEAS register to 0x%02X (temp_os=%d, press_os=%d, mode=sleep)\n", 
-           ctrl_meas_value, static_cast<int>(temperatureOversampling.e), static_cast<int>(pressureOversampling.e));
+        //    ctrl_meas_value, static_cast<int>(temperatureOversampling.e), static_cast<int>(pressureOversampling.e));
     
     // For SPI writes, register address MSB must be 0
     U8 config_sequence[] = {CTRL_MEAS_REGISTER & 0x7F, ctrl_meas_value}; // Clear MSB for write

--- a/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
@@ -364,9 +364,9 @@ Bmp280Data BmpManager ::convert_raw_data(const RawBmpData& raw, const Calibratio
     // Calculate altitude using barometric formula
     F32 altitude = calculate_altitude(pressure, seaLevelPressure);
 
-    bmpData.setpressure(pressure);
-    bmpData.settemperature(temperature);
-    bmpData.setaltitude(altitude);
+    bmpData.set_pressure(pressure);
+    bmpData.set_temperature(temperature);
+    bmpData.set_altitude(altitude);
 
     return bmpData;
 }

--- a/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
@@ -68,7 +68,8 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
 
         case CHIP_ID_CHECK: {
             U8 chip_id = 0;
-            if (this->read_chip_id(chip_id) && chip_id == CHIP_ID_VALUE) {
+            bool success = this->read_chip_id(chip_id); 
+            if (success && chip_id == CHIP_ID_VALUE) {
                 this->m_state = CALIBRATION_READ;
             } else {
                 this->m_state = RESET;
@@ -165,7 +166,7 @@ void BmpManager ::run_handler(FwIndexType portNum, U32 context) {
 bool BmpManager ::reset() {
     U8 reset_sequence[] = {RESET_REGISTER & 0x7F, RESET_VALUE};  // Clear MSB for write
     Fw::Buffer writeBuffer(reset_sequence, sizeof(reset_sequence));
-    Fw::Buffer readBuffer;
+    Fw::Buffer readBuffer(reset_sequence, sizeof(reset_sequence));
     bool success = this->spi_transfer(writeBuffer, readBuffer);
     return success;
 }
@@ -287,9 +288,9 @@ bool BmpManager ::trigger_measurement() {
 
 bool BmpManager ::spi_transfer(Fw::Buffer& writeBuffer, Fw::Buffer& readBuffer) {
     // Validate buffer sizes
-    FW_ASSERT(writeBuffer.getSize() == 0);
+    FW_ASSERT(writeBuffer.getSize() != 0);
 
-    FW_ASSERT(readBuffer.getSize() == 0);
+    FW_ASSERT(readBuffer.getSize() != 0);
 
     FW_ASSERT(writeBuffer.getSize() == readBuffer.getSize());
 

--- a/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
@@ -282,7 +282,7 @@ bool BmpManager ::trigger_measurement() {
     // For SPI writes, register address MSB must be 0
     U8 config_sequence[] = {CTRL_MEAS_REGISTER & 0x7F, ctrl_meas_value};  // Clear MSB for write
     Fw::Buffer writeBuffer(config_sequence, sizeof(config_sequence));
-    Fw::Buffer readBuffer;
+    Fw::Buffer readBuffer(config_sequence, sizeof(config_sequence));
     return this->spi_transfer(writeBuffer, readBuffer);
 }
 

--- a/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
@@ -1,6 +1,6 @@
 // ======================================================================
 // \title  BmpManager.cpp
-// \author Generated
+// \author aborjigin & Generated
 // \brief  cpp file for BmpManager component implementation class
 // ======================================================================
 

--- a/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
@@ -252,7 +252,7 @@ bool BmpManager ::configure_device() {
 
     U8 config_sequence[] = {CTRL_MEAS_REGISTER & 0x7F, ctrl_meas_value};  // Clear MSB for write
     Fw::Buffer writeBuffer(config_sequence, sizeof(config_sequence));
-    Fw::Buffer readBuffer;
+    Fw::Buffer readBuffer(config_sequence, sizeof(config_sequence));
 
     bool success = this->spi_transfer(writeBuffer, readBuffer);
 

--- a/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.fpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.fpp
@@ -24,13 +24,17 @@ module Bmp280 {
             error: U32
         ) severity warning high format "SPI error on device {} with error code {}" throttle 5
 
-        event DeviceResetFailed(
-            attempts: U32
-        ) severity warning high format "BMP280 Device reset failed {} times" throttle 5
+        event DeviceFailure() severity warning high format "BMP280 Device failure" throttle 5
 
-        event DeviceFailure(
-            
-        ) severity warning high format "BMP280 Device failure" throttle 5
+        event ChipIdCheckFailure() severity warning high format "BMP280 Chip ID check failure" throttle 5
+
+        event CalibrationFailure() severity warning high format "BMP280 Calibration Read failure" throttle 5
+
+        event DeviceConfigureFailure() severity warning high format "BMP280 Configure failure" throttle 5 
+
+        event MeasurementTriggerFailure() severity warning high format "BMP280 Measurement Trigger failure" throttle 5
+
+        event SpiTransferFailure() severity warning high format "BMP280 SPI Transfer failure" throttle 5
 
         @ Parameter for setting the pressure oversampling
         param PRESSURE_OVERSAMPLING: PressureOversampling default PressureOversampling.OVERSAMPLE_1X

--- a/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.fpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.fpp
@@ -24,6 +24,14 @@ module Bmp280 {
             error: U32
         ) severity warning high format "SPI error on device {} with error code {}" throttle 5
 
+        event DeviceResetFailed(
+            attempts: U32
+        ) severity warning high format "BMP280 Device reset failed {} times" throttle 5
+
+        event DeviceFailure(
+            
+        ) severity warning high format "BMP280 Device failure" throttle 5
+
         @ Parameter for setting the pressure oversampling
         param PRESSURE_OVERSAMPLING: PressureOversampling default PressureOversampling.OVERSAMPLE_1X
 

--- a/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.fpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.fpp
@@ -1,0 +1,67 @@
+module Bmp280 {
+    @ Component emitting telemetry read from a Bmp280
+    passive component BmpManager {
+
+        @ Port for SPI bus communication
+        output port spiReadWrite: Drv.SpiReadWrite
+
+        @ Scheduling port for reading from BMP280 and writing to telemetry
+        sync input port run: Svc.Sched
+
+        @ Telemetry channel for BMP280 data
+        telemetry Reading: Bmp280Data
+
+        event PressureOversamplingUpdated(
+            newOversampling: PressureOversampling
+        ) severity activity high format "Pressure oversampling updated to {}"
+
+        event TemperatureOversamplingUpdated(
+            newOversampling: TemperatureOversampling
+        ) severity activity high format "Temperature oversampling updated to {}"
+
+        event SpiError(
+            device: U32,
+            error: U32
+        ) severity warning high format "SPI error on device {} with error code {}" throttle 5
+
+        @ Parameter for setting the pressure oversampling
+        param PRESSURE_OVERSAMPLING: PressureOversampling default PressureOversampling.OVERSAMPLE_1X
+
+        @ Parameter for setting the temperature oversampling
+        param TEMPERATURE_OVERSAMPLING: TemperatureOversampling default TemperatureOversampling.OVERSAMPLE_1X
+
+        @ Parameter for setting the sea-level pressure for altitude calculation (Pa)
+        param SEA_LEVEL_PRESSURE: F32 default 101325.0
+
+        ###############################################################################
+        # Standard AC Ports: Required for Channels, Events, Commands, and Parameters  #
+        ###############################################################################
+        @ Port for requesting the current time
+        time get port timeCaller
+
+        @ Port for sending telemetry channels to downlink
+        telemetry port tlmOut
+
+        @ Command receive port
+        command recv port CmdDisp
+
+        @ Command registration port
+        command reg port CmdReg
+
+        @ Command response port
+        command resp port CmdStatus
+
+        @ Event port
+        event port Log
+
+        @ Text event port
+        text event port LogText
+
+        @ Parameter get port
+        param get port PrmGet
+
+        @ Parameter set port
+        param set port PrmSet
+
+    }
+} 

--- a/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.fpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.fpp
@@ -19,11 +19,6 @@ module Bmp280 {
             newOversampling: TemperatureOversampling
         ) severity activity high format "Temperature oversampling updated to {}"
 
-        event SpiError(
-            device: U32,
-            error: U32
-        ) severity warning high format "SPI error on device {} with error code {}" throttle 5
-
         event DeviceFailure() severity warning high format "BMP280 Device failure" throttle 5
 
         event ChipIdCheckFailure() severity warning high format "BMP280 Chip ID check failure" throttle 5
@@ -34,7 +29,7 @@ module Bmp280 {
 
         event MeasurementTriggerFailure() severity warning high format "BMP280 Measurement Trigger failure" throttle 5
 
-        event SpiTransferFailure() severity warning high format "BMP280 SPI Transfer failure" throttle 5
+        event DeviceReadFailure() severity warning high format "BMP280 Device Measurement Read failure" throttle 5
 
         @ Parameter for setting the pressure oversampling
         param PRESSURE_OVERSAMPLING: PressureOversampling default PressureOversampling.OVERSAMPLE_1X

--- a/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.hpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.hpp
@@ -1,6 +1,6 @@
 // ======================================================================
 // \title  BmpManager.hpp
-// \author Generated
+// \author aborjigin & Generated
 // \brief  hpp file for BmpManager component implementation class
 // ======================================================================
 

--- a/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.hpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.hpp
@@ -1,0 +1,127 @@
+// ======================================================================
+// \title  BmpManager.hpp
+// \author Generated
+// \brief  hpp file for BmpManager component implementation class
+// ======================================================================
+
+#ifndef Bmp280_BmpManager_HPP
+#define Bmp280_BmpManager_HPP
+
+#include "fprime-sensors/Bmp280/Components/BmpManager/BmpManagerComponentAc.hpp"
+
+namespace Bmp280 {
+
+class BmpManager final : public BmpManagerComponentBase {
+  public:
+    static constexpr U8 CHIP_ID_REGISTER = 0xD0;
+    static constexpr U8 CHIP_ID_VALUE = 0x58;
+    static constexpr U8 CTRL_MEAS_REGISTER = 0xF4;
+    static constexpr U8 CONFIG_REGISTER = 0xF5;
+    static constexpr U8 PRESSURE_MSB_REGISTER = 0xF7;
+    static constexpr U8 DEVICE_SELECT = 0; // SPI chip select
+    static constexpr U8 RESET_REGISTER = 0xE0;
+    static constexpr U8 RESET_VALUE = 0xB6;
+    static constexpr U8 STATUS_REGISTER = 0xF3;
+    static constexpr U8 CALIB_DATA_REGISTER = 0x88;
+    static constexpr U8 CALIB_DATA_LENGTH = 24;
+    static constexpr U8 MEASUREMENT_DATA_LENGTH = 6;
+    static constexpr U8 NORMAL_MODE = 0x03;
+    static constexpr U8 FORCED_MODE = 0x01;
+
+    struct CalibrationData {
+        U16 dig_T1;
+        I16 dig_T2;
+        I16 dig_T3;
+        U16 dig_P1;
+        I16 dig_P2;
+        I16 dig_P3;
+        I16 dig_P4;
+        I16 dig_P5;
+        I16 dig_P6;
+        I16 dig_P7;
+        I16 dig_P8;
+        I16 dig_P9;
+    };
+
+    struct RawBmpData {
+        U32 pressure;
+        U32 temperature;
+    };
+
+    // ----------------------------------------------------------------------
+    // Component construction and destruction
+    // ----------------------------------------------------------------------
+
+    //! Construct BmpManager object
+    BmpManager(const char* const compName  //!< The component name
+    );
+
+    //! Destroy BmpManager object
+    ~BmpManager();
+
+    //! Converts raw BMP280 data to the telemetry structure
+    static Bmp280Data convert_raw_data(const RawBmpData& raw,
+                                       const CalibrationData& calib,
+                                       F32 seaLevelPressure);
+
+    //! Calculates altitude from pressure using barometric formula
+    static F32 calculate_altitude(F32 pressure, F32 seaLevelPressure);
+
+    //! Pressure oversampling to register value
+    static U8 pressure_oversampling_to_register(PressureOversampling oversampling);
+
+    //! Temperature oversampling to register value
+    static U8 temperature_oversampling_to_register(TemperatureOversampling oversampling);
+
+  private:
+    // ----------------------------------------------------------------------
+    // Handler implementations for typed input ports
+    // ----------------------------------------------------------------------
+
+    //! Emit parameter updated EVR
+    //!
+    void parameterUpdated(FwPrmIdType id  //!< The parameter ID
+                          ) override;
+
+    //! Handler implementation for run
+    //!
+    //! Scheduling port for reading from BMP280 and writing to telemetry
+    void run_handler(FwIndexType portNum,  //!< The port number
+                     U32 context           //!< The call order
+                     ) override;
+
+    // ----------------------------------------------------------------------
+    // Helper functions
+    // ----------------------------------------------------------------------
+
+    //! Resets the BMP280
+    bool reset();
+
+    //! Read the chip ID
+    bool read_chip_id(U8& id);
+
+    //! Read calibration data
+    bool read_calibration_data();
+
+    //! Configure the BMP280
+    bool configure_device();
+
+    //! Write to the SPI bus and handle errors
+    bool spi_transfer(Fw::Buffer& writeBuffer, Fw::Buffer& readBuffer);
+
+    //! Deserializes raw data from the bus
+    RawBmpData deserialize_raw_data(Fw::Buffer& buffer);
+
+    //! State of the BMP280 component
+    enum BmpState { RESET, CHIP_ID_CHECK, CALIBRATION_READ, CONFIGURE, RUNNING };
+
+    //! Tracks the state of the BMP280
+    BmpState m_state;
+
+    //! Calibration data
+    CalibrationData m_calibration;
+};
+
+}  // namespace Bmp280
+
+#endif 

--- a/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.hpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.hpp
@@ -123,9 +123,6 @@ class BmpManager final : public BmpManagerComponentBase {
 
     //! Tracks the state of the BMP280
     BmpState m_state;
-
-    //! Reset attempt counter
-    U32 m_resetAttempts;
     
     //! Startup delay counter
     U32 m_startupCounter;

--- a/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.hpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.hpp
@@ -100,11 +100,17 @@ class BmpManager final : public BmpManagerComponentBase {
     //! Read the chip ID
     bool read_chip_id(U8& id);
 
+    //! Read the status register
+    bool read_status(U8& status);
+
     //! Read calibration data
     bool read_calibration_data();
 
     //! Configure the BMP280
     bool configure_device();
+    
+    //! Trigger a measurement in forced mode
+    bool trigger_measurement();
 
     //! Write to the SPI bus and handle errors
     bool spi_transfer(Fw::Buffer& writeBuffer, Fw::Buffer& readBuffer);
@@ -113,13 +119,25 @@ class BmpManager final : public BmpManagerComponentBase {
     RawBmpData deserialize_raw_data(Fw::Buffer& buffer);
 
     //! State of the BMP280 component
-    enum BmpState { RESET, CHIP_ID_CHECK, CALIBRATION_READ, CONFIGURE, RUNNING };
+    enum BmpState { RESET, STARTUP_DELAY, CHIP_ID_CHECK, CALIBRATION_READ, CONFIGURE, RUNNING };
 
     //! Tracks the state of the BMP280
     BmpState m_state;
 
+    //! Reset attempt counter
+    U32 m_resetAttempts;
+    
+    //! Startup delay counter
+    U32 m_startupCounter;
+
     //! Calibration data
     CalibrationData m_calibration;
+    
+    //! Maximum number of reset attempts before giving up
+    static constexpr U32 MAX_RESET_ATTEMPTS = 5;
+    
+    //! Number of cycles to wait after reset for device startup (approximately 2ms at typical scheduling rates)
+    static constexpr U32 STARTUP_DELAY_CYCLES = 2;
 };
 
 }  // namespace Bmp280

--- a/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.hpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.hpp
@@ -18,7 +18,7 @@ class BmpManager final : public BmpManagerComponentBase {
     static constexpr U8 CTRL_MEAS_REGISTER = 0xF4;
     static constexpr U8 CONFIG_REGISTER = 0xF5;
     static constexpr U8 PRESSURE_MSB_REGISTER = 0xF7;
-    static constexpr U8 DEVICE_SELECT = 0; // SPI chip select
+    static constexpr U8 DEVICE_SELECT = 0;  // SPI chip select
     static constexpr U8 RESET_REGISTER = 0xE0;
     static constexpr U8 RESET_VALUE = 0xB6;
     static constexpr U8 STATUS_REGISTER = 0xF3;
@@ -60,9 +60,7 @@ class BmpManager final : public BmpManagerComponentBase {
     ~BmpManager();
 
     //! Converts raw BMP280 data to the telemetry structure
-    static Bmp280Data convert_raw_data(const RawBmpData& raw,
-                                       const CalibrationData& calib,
-                                       F32 seaLevelPressure);
+    static Bmp280Data convert_raw_data(const RawBmpData& raw, const CalibrationData& calib, F32 seaLevelPressure);
 
     //! Calculates altitude from pressure using barometric formula
     static F32 calculate_altitude(F32 pressure, F32 seaLevelPressure);
@@ -108,7 +106,7 @@ class BmpManager final : public BmpManagerComponentBase {
 
     //! Configure the BMP280
     bool configure_device();
-    
+
     //! Trigger a measurement in forced mode
     bool trigger_measurement();
 
@@ -123,20 +121,20 @@ class BmpManager final : public BmpManagerComponentBase {
 
     //! Tracks the state of the BMP280
     BmpState m_state;
-    
+
     //! Startup delay counter
     U32 m_startupCounter;
 
     //! Calibration data
     CalibrationData m_calibration;
-    
+
     //! Maximum number of reset attempts before giving up
     static constexpr U32 MAX_RESET_ATTEMPTS = 5;
-    
+
     //! Number of cycles to wait after reset for device startup (approximately 2ms at typical scheduling rates)
     static constexpr U32 STARTUP_DELAY_CYCLES = 2;
 };
 
 }  // namespace Bmp280
 
-#endif 
+#endif

--- a/fprime-sensors/Bmp280/Components/BmpManager/CMakeLists.txt
+++ b/fprime-sensors/Bmp280/Components/BmpManager/CMakeLists.txt
@@ -15,9 +15,6 @@ register_fprime_module(
         "${CMAKE_CURRENT_LIST_DIR}/BmpManager.fpp"
     SOURCES
         "${CMAKE_CURRENT_LIST_DIR}/BmpManager.cpp"
-    # MOD_DEPS
-    #     fprime-sensors_Bmp280_Types
-    #     Drv_SpiDriverPorts
 )
 
 register_fprime_ut(

--- a/fprime-sensors/Bmp280/Components/BmpManager/CMakeLists.txt
+++ b/fprime-sensors/Bmp280/Components/BmpManager/CMakeLists.txt
@@ -1,0 +1,32 @@
+####
+# FPrime CMakeLists.txt:
+#
+# SOURCE_FILES: combined list of source and autocoding files
+# MOD_DEPS: (optional) module dependencies
+# UT_SOURCE_FILES: list of source files for unit tests
+#
+# More information in the F´ CMake API documentation:
+# https://fprime.jpl.nasa.gov/latest/docs/user-manual/build-system/cmake-api/
+#
+####
+
+register_fprime_module(
+    AUTOCODER_INPUTS
+        "${CMAKE_CURRENT_LIST_DIR}/BmpManager.fpp"
+    SOURCES
+        "${CMAKE_CURRENT_LIST_DIR}/BmpManager.cpp"
+    # MOD_DEPS
+    #     fprime-sensors_Bmp280_Types
+    #     Drv_SpiDriverPorts
+)
+
+register_fprime_ut(
+    AUTOCODER_INPUTS
+        "${CMAKE_CURRENT_LIST_DIR}/BmpManager.fpp"
+    SOURCES
+        "${CMAKE_CURRENT_LIST_DIR}/test/ut/BmpManagerTestMain.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/test/ut/BmpManagerTester.cpp"
+    DEPENDS
+        STest
+    UT_AUTO_HELPERS
+) 

--- a/fprime-sensors/Bmp280/Components/BmpManager/docs/sdd.md
+++ b/fprime-sensors/Bmp280/Components/BmpManager/docs/sdd.md
@@ -1,66 +1,99 @@
 # Bmp280::BmpManager
 
-Component emitting telemetry read from a Bmp280
-
-## Usage Examples
-Add usage examples here
-
-### Diagrams
-Add diagrams here
-
-### Typical Usage
-And the typical usage of the component here
-
-## Class Diagram
-Add a class diagram here
-
-## Port Descriptions
-| Name | Description |
-|---|---|
-|---|---|
-
-## Component States
-Add component states in the chart below
-| Name | Description |
-|---|---|
-|---|---|
-
-## Sequence Diagrams
-Add sequence diagrams here
-
-## Parameters
-| Name | Description |
-|---|---|
-|---|---|
-
-## Commands
-| Name | Description |
-|---|---|
-|---|---|
-
-## Events
-| Name | Description |
-|---|---|
-|---|---|
-
-## Telemetry
-| Name | Description |
-|---|---|
-|---|---|
-
-## Unit Tests
-Add unit test descriptions in the chart below
-| Name | Description | Output | Coverage |
-|---|---|---|---|
-|---|---|---|---|
+Component emitting telemetry read from a BMP280 digital pressure sensor. This component communicates with the BMP280 sensor via SPI interface and provides barometric pressure, temperature, and calculated altitude data. All calculations follow the compensation formulas specified in the BMP280 datasheet: https://cdn-shop.adafruit.com/datasheets/BST-BMP280-DS001-11.pdf
 
 ## Requirements
-Add requirements in the chart below
+
 | Name | Description | Validation |
 |---|---|---|
-|---|---|---|
+| BMP280-001 | The BmpManager shall emit barometric pressure data in units of Pa (Pascals) | Unit-Test |
+| BMP280-002 | The BmpManager shall emit temperature data in units of °C (degrees Celsius) | Unit-Test |
+| BMP280-003 | The BmpManager shall emit altitude data in units of m (meters) | Unit-Test |
+| BMP280-004 | The BmpManager shall communicate with the BMP280 sensor using SPI interface | Unit-Test |
+| BMP280-005 | The BmpManager shall use compensation formulas from the BMP280 datasheet for accurate readings | Unit-Test |
+| BMP280-006 | The BmpManager shall read calibration data from the sensor for temperature and pressure compensation | Unit-Test |
+| BMP280-007 | The BmpManager shall verify sensor chip ID matches expected BMP280 value (0x58) | Unit-Test |
 
-## Change Log
-| Date | Description |
+**SPI Configuration Note**: If you wish to change the SPI connection settings, modify the device and chip select values in `fprime-sensors-reference/ReferenceDeployment/Main.cpp` at lines 96-97:
+```cpp
+inputs.bmp.device.device = 0; // SPI bus 0
+inputs.bmp.device.select = 0; // SPI chip select 0
+```
+
+## Port Descriptions
+
+| Name | Description |
 |---|---|
-|---| Initial Draft | 
+| run | Scheduling input port for periodic sensor reading and telemetry emission |
+| spiReadWrite | Output port for SPI bus communication with the BMP280 sensor |
+| timeCaller | Port for requesting current time for telemetry timestamps |
+| tlmOut | Port for sending telemetry channels to downlink |
+| CmdDisp | Command receive port for handling component commands |
+| CmdReg | Command registration port |
+| CmdStatus | Command response port |
+| LogText | Text event port for logging messages |
+| PrmGet | Parameter get port |
+| PrmSet | Parameter set port |
+
+## Component States
+
+The BmpManager operates as a finite state machine with the following states:
+
+| Name | Description |
+|---|---|
+| RESET | Initial state where the component sends a reset command to the BMP280 sensor. Retries up to 5 times if reset fails. |
+| STARTUP_DELAY | Waits for the sensor to complete its startup sequence after reset (approximately 2ms delay). |
+| CHIP_ID_CHECK | Reads and verifies the sensor's chip ID register (0xD0) matches the expected BMP280 value (0x58). |
+| CALIBRATION_READ | Reads 24 bytes of calibration data from registers starting at 0x88, used for temperature and pressure compensation. |
+| CONFIGURE | Configures the sensor with pressure and temperature oversampling settings based on component parameters. |
+| RUNNING | Normal operation state where the component triggers measurements in forced mode and reads sensor data for telemetry. |
+
+State transitions occur based on successful completion of operations. Any failure in states CHIP_ID_CHECK through RUNNING will cause the component to return to RESET state.
+
+## Parameters
+
+| Name | Description |
+|---|---|
+| PRESSURE_OVERSAMPLING | Controls pressure measurement oversampling (SKIP, 1X, 2X, 4X, 8X, 16X). Default: OVERSAMPLE_1X |
+| TEMPERATURE_OVERSAMPLING | Controls temperature measurement oversampling (SKIP, 1X, 2X, 4X, 8X, 16X). Default: OVERSAMPLE_1X |
+| SEA_LEVEL_PRESSURE | Sea-level pressure in Pa used for altitude calculation. Default: 101325.0 Pa |
+
+**SEA_LEVEL_PRESSURE Configuration Note**: Can change in GDS as command or change the default in `BmpManager.fpp` line 34
+``` 
+param SEA_LEVEL_PRESSURE: F32 default 101325.0
+```
+
+
+## Events
+
+| Name | Description |
+|---|---|
+| PressureOversamplingUpdated | Emitted when pressure oversampling parameter is updated |
+| TemperatureOversamplingUpdated | Emitted when temperature oversampling parameter is updated |
+| SpiError | Warning event emitted when SPI communication fails (throttled to prevent spam) |
+
+## Telemetry
+
+| Name | Description |
+|---|---|
+| Reading | BMP280 sensor data containing pressure (Pa), temperature (°C), and calculated altitude (m) |
+
+The telemetry structure (`Bmp280Data`) contains:
+- **pressure**: Barometric pressure in Pascals, compensated using BMP280 datasheet formulas
+- **temperature**: Temperature in degrees Celsius, compensated using BMP280 datasheet formulas  
+- **altitude**: Calculated altitude in meters using the barometric formula and sea-level pressure parameter
+
+## Unit Tests
+
+| Name | Description | Output | Coverage |
+|---|---|---|---|
+| TestInitialState | Verify component starts in RESET state | Component initializes properly | State machine initialization |
+| TestChipIdValidation | Test chip ID reading and validation | Correct chip ID verification | Chip ID check functionality |
+| TestCalibrationDataRead | Verify calibration data is read correctly | Calibration coefficients populated | Calibration reading |
+| TestDataConversion | Test raw sensor data conversion to engineering units | Accurate pressure, temperature, altitude | Data compensation algorithms |
+| TestSpiCommunication | Verify SPI read/write operations | Successful sensor communication | SPI interface |
+| TestStateTransitions | Verify proper state machine transitions | Correct state progression | State machine logic |
+
+## Debugging 
+**Debugging Note**: 
+In `BmpManager.cpp`, there are several commented `printf` statements used for debugging. Uncomment for debugging help. 

--- a/fprime-sensors/Bmp280/Components/BmpManager/docs/sdd.md
+++ b/fprime-sensors/Bmp280/Components/BmpManager/docs/sdd.md
@@ -1,0 +1,66 @@
+# Bmp280::BmpManager
+
+Component emitting telemetry read from a Bmp280
+
+## Usage Examples
+Add usage examples here
+
+### Diagrams
+Add diagrams here
+
+### Typical Usage
+And the typical usage of the component here
+
+## Class Diagram
+Add a class diagram here
+
+## Port Descriptions
+| Name | Description |
+|---|---|
+|---|---|
+
+## Component States
+Add component states in the chart below
+| Name | Description |
+|---|---|
+|---|---|
+
+## Sequence Diagrams
+Add sequence diagrams here
+
+## Parameters
+| Name | Description |
+|---|---|
+|---|---|
+
+## Commands
+| Name | Description |
+|---|---|
+|---|---|
+
+## Events
+| Name | Description |
+|---|---|
+|---|---|
+
+## Telemetry
+| Name | Description |
+|---|---|
+|---|---|
+
+## Unit Tests
+Add unit test descriptions in the chart below
+| Name | Description | Output | Coverage |
+|---|---|---|---|
+|---|---|---|---|
+
+## Requirements
+Add requirements in the chart below
+| Name | Description | Validation |
+|---|---|---|
+|---|---|---|
+
+## Change Log
+| Date | Description |
+|---|---|
+|---| Initial Draft | 

--- a/fprime-sensors/Bmp280/Components/BmpManager/test/ut/BmpManagerTestMain.cpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/test/ut/BmpManagerTestMain.cpp
@@ -1,0 +1,22 @@
+// ======================================================================
+// \title  BmpManagerTestMain.cpp
+// \author Generated
+// \brief  test main for BmpManager component
+// ======================================================================
+
+#include "BmpManagerTester.hpp"
+
+TEST(Nominal, Test) {
+    Bmp280::BmpManagerTester tester;
+    tester.test_nominal();
+}
+
+TEST(Error, Test) {
+    Bmp280::BmpManagerTester tester;
+    tester.test_error();
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+} 

--- a/fprime-sensors/Bmp280/Components/BmpManager/test/ut/BmpManagerTestMain.cpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/test/ut/BmpManagerTestMain.cpp
@@ -19,4 +19,4 @@ TEST(Error, Test) {
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
-} 
+}

--- a/fprime-sensors/Bmp280/Components/BmpManager/test/ut/BmpManagerTester.cpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/test/ut/BmpManagerTester.cpp
@@ -1,0 +1,90 @@
+// ======================================================================
+// \title  BmpManagerTester.cpp
+// \author Generated
+// \brief  cpp file for BmpManager component test harness implementation class
+// ======================================================================
+
+#include "BmpManagerTester.hpp"
+
+namespace Bmp280 {
+
+// ----------------------------------------------------------------------
+// Construction and destruction
+// ----------------------------------------------------------------------
+
+BmpManagerTester ::BmpManagerTester() : BmpManagerGTestBase("BmpManagerTester", BmpManagerTester::MAX_HISTORY_SIZE), component("BmpManager") {
+    this->initComponents();
+    this->connectPorts();
+}
+
+BmpManagerTester ::~BmpManagerTester() {}
+
+// ----------------------------------------------------------------------
+// Tests
+// ----------------------------------------------------------------------
+
+void BmpManagerTester ::test_nominal() {
+    // Test nominal operation
+    this->invoke_to_run(0, 0);
+    
+    // Verify telemetry was sent
+    ASSERT_TLM_SIZE(1);
+    ASSERT_TLM_Reading_SIZE(1);
+    
+    // Verify no events were emitted
+    ASSERT_EVENTS_SIZE(0);
+}
+
+void BmpManagerTester ::test_error() {
+    // Test error cases
+    this->invoke_to_run(0, 0);
+    
+    // Verify error event was emitted
+    ASSERT_EVENTS_SIZE(1);
+    ASSERT_EVENTS_I2cError_SIZE(1);
+}
+
+// ----------------------------------------------------------------------
+// Handlers for typed from ports
+// ----------------------------------------------------------------------
+
+void BmpManagerTester ::from_busWriteRead_handler(FwIndexType portNum,
+                                                   U32 addr,
+                                                   Fw::Buffer& writeBuffer,
+                                                   Fw::Buffer& readBuffer) {
+    this->pushFromPortEntry_busWriteRead(addr, writeBuffer, readBuffer);
+}
+
+void BmpManagerTester ::from_busWrite_handler(FwIndexType portNum,
+                                               U32 addr,
+                                               Fw::Buffer& writeBuffer) {
+    this->pushFromPortEntry_busWrite(addr, writeBuffer);
+}
+
+// ----------------------------------------------------------------------
+// Helper functions
+// ----------------------------------------------------------------------
+
+void BmpManagerTester ::connectPorts() {
+    // Connect ports
+    this->connect_to_run(0, this->component.get_run_InputPort(0));
+    this->connect_to_timeCaller(0, this->component.get_timeCaller_OutputPort(0));
+    this->connect_to_CmdDisp(0, this->component.get_CmdDisp_OutputPort(0));
+    this->connect_to_CmdReg(0, this->component.get_CmdReg_OutputPort(0));
+    this->connect_to_CmdStatus(0, this->component.get_CmdStatus_OutputPort(0));
+    this->connect_to_Log(0, this->component.get_Log_OutputPort(0));
+    this->connect_to_LogText(0, this->component.get_LogText_OutputPort(0));
+    this->connect_to_tlmOut(0, this->component.get_tlmOut_OutputPort(0));
+    this->connect_to_PrmGet(0, this->component.get_PrmGet_OutputPort(0));
+    this->connect_to_PrmSet(0, this->component.get_PrmSet_OutputPort(0));
+    
+    this->component.set_busWriteRead_OutputPort(0, this->get_from_busWriteRead(0));
+    this->component.set_busWrite_OutputPort(0, this->get_from_busWrite(0));
+}
+
+void BmpManagerTester ::initComponents() {
+    this->init();
+    this->component.init(BmpManagerTester::TEST_INSTANCE_QUEUE_DEPTH, BmpManagerTester::TEST_INSTANCE_ID);
+}
+
+}  // namespace Bmp280 

--- a/fprime-sensors/Bmp280/Components/BmpManager/test/ut/BmpManagerTester.cpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/test/ut/BmpManagerTester.cpp
@@ -12,7 +12,8 @@ namespace Bmp280 {
 // Construction and destruction
 // ----------------------------------------------------------------------
 
-BmpManagerTester ::BmpManagerTester() : BmpManagerGTestBase("BmpManagerTester", BmpManagerTester::MAX_HISTORY_SIZE), component("BmpManager") {
+BmpManagerTester ::BmpManagerTester()
+    : BmpManagerGTestBase("BmpManagerTester", BmpManagerTester::MAX_HISTORY_SIZE), component("BmpManager") {
     this->initComponents();
     this->connectPorts();
 }
@@ -26,11 +27,11 @@ BmpManagerTester ::~BmpManagerTester() {}
 void BmpManagerTester ::test_nominal() {
     // Test nominal operation
     this->invoke_to_run(0, 0);
-    
+
     // Verify telemetry was sent
     ASSERT_TLM_SIZE(1);
     ASSERT_TLM_Reading_SIZE(1);
-    
+
     // Verify no events were emitted
     ASSERT_EVENTS_SIZE(0);
 }
@@ -38,7 +39,7 @@ void BmpManagerTester ::test_nominal() {
 void BmpManagerTester ::test_error() {
     // Test error cases
     this->invoke_to_run(0, 0);
-    
+
     // Verify error event was emitted
     ASSERT_EVENTS_SIZE(1);
     ASSERT_EVENTS_I2cError_SIZE(1);
@@ -49,15 +50,13 @@ void BmpManagerTester ::test_error() {
 // ----------------------------------------------------------------------
 
 void BmpManagerTester ::from_busWriteRead_handler(FwIndexType portNum,
-                                                   U32 addr,
-                                                   Fw::Buffer& writeBuffer,
-                                                   Fw::Buffer& readBuffer) {
+                                                  U32 addr,
+                                                  Fw::Buffer& writeBuffer,
+                                                  Fw::Buffer& readBuffer) {
     this->pushFromPortEntry_busWriteRead(addr, writeBuffer, readBuffer);
 }
 
-void BmpManagerTester ::from_busWrite_handler(FwIndexType portNum,
-                                               U32 addr,
-                                               Fw::Buffer& writeBuffer) {
+void BmpManagerTester ::from_busWrite_handler(FwIndexType portNum, U32 addr, Fw::Buffer& writeBuffer) {
     this->pushFromPortEntry_busWrite(addr, writeBuffer);
 }
 
@@ -77,7 +76,7 @@ void BmpManagerTester ::connectPorts() {
     this->connect_to_tlmOut(0, this->component.get_tlmOut_OutputPort(0));
     this->connect_to_PrmGet(0, this->component.get_PrmGet_OutputPort(0));
     this->connect_to_PrmSet(0, this->component.get_PrmSet_OutputPort(0));
-    
+
     this->component.set_busWriteRead_OutputPort(0, this->get_from_busWriteRead(0));
     this->component.set_busWrite_OutputPort(0, this->get_from_busWrite(0));
 }
@@ -87,4 +86,4 @@ void BmpManagerTester ::initComponents() {
     this->component.init(BmpManagerTester::TEST_INSTANCE_QUEUE_DEPTH, BmpManagerTester::TEST_INSTANCE_ID);
 }
 
-}  // namespace Bmp280 
+}  // namespace Bmp280

--- a/fprime-sensors/Bmp280/Components/BmpManager/test/ut/BmpManagerTester.hpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/test/ut/BmpManagerTester.hpp
@@ -1,0 +1,76 @@
+// ======================================================================
+// \title  BmpManagerTester.hpp
+// \author Generated
+// \brief  hpp file for BmpManager component test harness implementation class
+// ======================================================================
+
+#ifndef Bmp280_BmpManagerTester_HPP
+#define Bmp280_BmpManagerTester_HPP
+
+#include "fprime-sensors/Bmp280/Components/BmpManager/BmpManagerGTestBase.hpp"
+#include "fprime-sensors/Bmp280/Components/BmpManager/BmpManager.hpp"
+
+namespace Bmp280 {
+
+class BmpManagerTester : public BmpManagerGTestBase {
+  public:
+    // ----------------------------------------------------------------------
+    // Construction and destruction
+    // ----------------------------------------------------------------------
+
+    //! Construct object BmpManagerTester
+    BmpManagerTester();
+
+    //! Destroy object BmpManagerTester
+    ~BmpManagerTester();
+
+  public:
+    // ----------------------------------------------------------------------
+    // Tests
+    // ----------------------------------------------------------------------
+
+    //! Test nominal operation
+    void test_nominal();
+
+    //! Test error cases
+    void test_error();
+
+  private:
+    // ----------------------------------------------------------------------
+    // Handlers for typed from ports
+    // ----------------------------------------------------------------------
+
+    //! Handler for from_busWriteRead
+    void from_busWriteRead_handler(FwIndexType portNum,
+                                   U32 addr,
+                                   Fw::Buffer& writeBuffer,
+                                   Fw::Buffer& readBuffer);
+
+    //! Handler for from_busWrite
+    void from_busWrite_handler(FwIndexType portNum,
+                               U32 addr,
+                               Fw::Buffer& writeBuffer);
+
+  private:
+    // ----------------------------------------------------------------------
+    // Helper functions
+    // ----------------------------------------------------------------------
+
+    //! Connect ports
+    void connectPorts();
+
+    //! Initialize components
+    void initComponents();
+
+  private:
+    // ----------------------------------------------------------------------
+    // Member variables
+    // ----------------------------------------------------------------------
+
+    //! The component under test
+    BmpManager component;
+};
+
+}  // namespace Bmp280
+
+#endif 

--- a/fprime-sensors/Bmp280/Components/BmpManager/test/ut/BmpManagerTester.hpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/test/ut/BmpManagerTester.hpp
@@ -7,8 +7,8 @@
 #ifndef Bmp280_BmpManagerTester_HPP
 #define Bmp280_BmpManagerTester_HPP
 
-#include "fprime-sensors/Bmp280/Components/BmpManager/BmpManagerGTestBase.hpp"
 #include "fprime-sensors/Bmp280/Components/BmpManager/BmpManager.hpp"
+#include "fprime-sensors/Bmp280/Components/BmpManager/BmpManagerGTestBase.hpp"
 
 namespace Bmp280 {
 
@@ -41,15 +41,10 @@ class BmpManagerTester : public BmpManagerGTestBase {
     // ----------------------------------------------------------------------
 
     //! Handler for from_busWriteRead
-    void from_busWriteRead_handler(FwIndexType portNum,
-                                   U32 addr,
-                                   Fw::Buffer& writeBuffer,
-                                   Fw::Buffer& readBuffer);
+    void from_busWriteRead_handler(FwIndexType portNum, U32 addr, Fw::Buffer& writeBuffer, Fw::Buffer& readBuffer);
 
     //! Handler for from_busWrite
-    void from_busWrite_handler(FwIndexType portNum,
-                               U32 addr,
-                               Fw::Buffer& writeBuffer);
+    void from_busWrite_handler(FwIndexType portNum, U32 addr, Fw::Buffer& writeBuffer);
 
   private:
     // ----------------------------------------------------------------------
@@ -73,4 +68,4 @@ class BmpManagerTester : public BmpManagerGTestBase {
 
 }  // namespace Bmp280
 
-#endif 
+#endif

--- a/fprime-sensors/Bmp280/Components/CMakeLists.txt
+++ b/fprime-sensors/Bmp280/Components/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/BmpManager/") 

--- a/fprime-sensors/Bmp280/Subtopology/Bmp280Config/Bmp280SubtopologyConfig.fpp
+++ b/fprime-sensors/Bmp280/Subtopology/Bmp280Config/Bmp280SubtopologyConfig.fpp
@@ -5,8 +5,12 @@ module Bmp280 {
 
     instance bmpDriver: Drv.LinuxSpiDriver base id Bmp280.SubtopologyConfig.BASE_ID + 0x00002000 {
         phase Fpp.ToCpp.Phases.configComponents """
+        printf("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
         if (not Bmp280::bmpDriver.open(state.bmp.device.device, state.bmp.device.select, Drv::SPI_FREQUENCY_5MHZ)) {
             Fw::Logger::log("[ERROR] BMP280 SPI open failed\\n");
+        }
+        else {
+            Fw::Logger::log("[INFO] BMP280 SPI open successful\\n");
         }
         """
     }

--- a/fprime-sensors/Bmp280/Subtopology/Bmp280Config/Bmp280SubtopologyConfig.fpp
+++ b/fprime-sensors/Bmp280/Subtopology/Bmp280Config/Bmp280SubtopologyConfig.fpp
@@ -5,7 +5,6 @@ module Bmp280 {
 
     instance bmpDriver: Drv.LinuxSpiDriver base id Bmp280.SubtopologyConfig.BASE_ID + 0x00002000 {
         phase Fpp.ToCpp.Phases.configComponents """
-        printf("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
         if (not Bmp280::bmpDriver.open(state.bmp.device.device, state.bmp.device.select, Drv::SPI_FREQUENCY_5MHZ)) {
             Fw::Logger::log("[ERROR] BMP280 SPI open failed\\n");
         }

--- a/fprime-sensors/Bmp280/Subtopology/Bmp280Config/Bmp280SubtopologyConfig.fpp
+++ b/fprime-sensors/Bmp280/Subtopology/Bmp280Config/Bmp280SubtopologyConfig.fpp
@@ -5,7 +5,7 @@ module Bmp280 {
 
     instance bmpDriver: Drv.LinuxSpiDriver base id Bmp280.SubtopologyConfig.BASE_ID + 0x00002000 {
         phase Fpp.ToCpp.Phases.configComponents """
-        if (not Bmp280::bmpDriver.open(state.bmp.device, state.bmp.select, Drv::SPI_FREQUENCY_5MHZ)) {
+        if (not Bmp280::bmpDriver.open(state.bmp.device.device, state.bmp.device.select, Drv::SPI_FREQUENCY_5MHZ)) {
             Fw::Logger::log("[ERROR] BMP280 SPI open failed\\n");
         }
         """

--- a/fprime-sensors/Bmp280/Subtopology/Bmp280Config/Bmp280SubtopologyConfig.fpp
+++ b/fprime-sensors/Bmp280/Subtopology/Bmp280Config/Bmp280SubtopologyConfig.fpp
@@ -1,0 +1,13 @@
+module Bmp280 {
+    module SubtopologyConfig {
+        constant BASE_ID = 0xD0000000
+    }
+
+    instance bmpDriver: Drv.LinuxSpiDriver base id Bmp280.SubtopologyConfig.BASE_ID + 0x00002000 {
+        phase Fpp.ToCpp.Phases.configComponents """
+        if (not Bmp280::bmpDriver.open(state.bmp.device, state.bmp.select, Drv::SPI_FREQUENCY_5MHZ)) {
+            Fw::Logger::log("[ERROR] BMP280 SPI open failed\\n");
+        }
+        """
+    }
+} 

--- a/fprime-sensors/Bmp280/Subtopology/Bmp280Config/Bmp280SubtopologyConfig.hpp
+++ b/fprime-sensors/Bmp280/Subtopology/Bmp280Config/Bmp280SubtopologyConfig.hpp
@@ -7,8 +7,8 @@
 #define Bmp280_Bmp280SubtopologyConfig_hpp
 
 struct BmpDevice {
-    const char* device;
-    int select;
+    int device;  // SPI bus number (e.g., 0 for SPI bus 0)
+    int select;  // SPI chip select pin (e.g., 0 for CS0)
 };
 
 #endif // Bmp280_Bmp280SubtopologyConfig_hpp 

--- a/fprime-sensors/Bmp280/Subtopology/Bmp280Config/Bmp280SubtopologyConfig.hpp
+++ b/fprime-sensors/Bmp280/Subtopology/Bmp280Config/Bmp280SubtopologyConfig.hpp
@@ -1,0 +1,14 @@
+// ======================================================================
+// \title  Bmp280SubtopologyConfig.hpp
+// \brief required header file containing the required definitions for the subtopology autocoder
+//
+// ======================================================================
+#ifndef Bmp280_Bmp280SubtopologyConfig_hpp
+#define Bmp280_Bmp280SubtopologyConfig_hpp
+
+struct BmpDevice {
+    const char* device;
+    int select;
+};
+
+#endif // Bmp280_Bmp280SubtopologyConfig_hpp 

--- a/fprime-sensors/Bmp280/Subtopology/Bmp280Config/CMakeLists.txt
+++ b/fprime-sensors/Bmp280/Subtopology/Bmp280Config/CMakeLists.txt
@@ -1,0 +1,6 @@
+register_fprime_config(
+    AUTOCODER_INPUTS
+        "${CMAKE_CURRENT_LIST_DIR}/Bmp280SubtopologyConfig.fpp"
+    DEPENDS
+        Fw_Types
+)

--- a/fprime-sensors/Bmp280/Subtopology/CMakeLists.txt
+++ b/fprime-sensors/Bmp280/Subtopology/CMakeLists.txt
@@ -3,5 +3,7 @@ add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Bmp280Config")
 register_fprime_module(
     AUTOCODER_INPUTS
         "${CMAKE_CURRENT_LIST_DIR}/Subtopology.fpp"
-    
+    DEPENDS
+        fprime-sensors_Bmp280_Subtopology_Bmp280Config
+
 ) 

--- a/fprime-sensors/Bmp280/Subtopology/CMakeLists.txt
+++ b/fprime-sensors/Bmp280/Subtopology/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Bmp280Config")
+
+register_fprime_module(
+    AUTOCODER_INPUTS
+        "${CMAKE_CURRENT_LIST_DIR}/Subtopology.fpp"
+    
+) 

--- a/fprime-sensors/Bmp280/Subtopology/Subtopology.fpp
+++ b/fprime-sensors/Bmp280/Subtopology/Subtopology.fpp
@@ -1,0 +1,13 @@
+module Bmp280 {
+    @ Manager overseeing the BMP280
+    instance bmpManager: Bmp280.BmpManager base id Bmp280.SubtopologyConfig.BASE_ID + 0x00001000
+
+    topology Subtopology {
+        instance bmpManager
+        instance bmpDriver
+
+        connections Bmp280 {
+            bmpManager.spiReadWrite -> bmpDriver.SpiReadWrite
+        }
+    }
+} 

--- a/fprime-sensors/Bmp280/Subtopology/SubtopologyTopologyDefs.hpp
+++ b/fprime-sensors/Bmp280/Subtopology/SubtopologyTopologyDefs.hpp
@@ -1,0 +1,21 @@
+// ======================================================================
+// \title  SubtopologyTopologyDefs.hpp
+// \brief subtopology definitions header
+//
+// ======================================================================
+#ifndef Bmp280_SubtopologyTopologyDefs_hpp
+#define Bmp280_SubtopologyTopologyDefs_hpp
+
+#include <Fw/Logger/Logger.hpp>
+#include "Bmp280Config/Bmp280SubtopologyConfig.hpp"
+
+namespace Bmp280 {
+    struct SubtopologyState {
+        BmpDevice device;
+    };
+
+    struct TopologyState {
+        SubtopologyState bmp;
+    };
+}
+#endif // Bmp280_SubtopologyTopologyDefs_hpp 

--- a/fprime-sensors/Bmp280/Types/CMakeLists.txt
+++ b/fprime-sensors/Bmp280/Types/CMakeLists.txt
@@ -1,0 +1,28 @@
+####
+# FPrime CMakeLists.txt:
+#
+# SOURCE_FILES: combined list of source and autocoding files
+# MOD_DEPS: (optional) module dependencies
+# UT_SOURCE_FILES: list of source files for unit tests
+#
+# More information in the F´ CMake API documentation:
+# https://fprime.jpl.nasa.gov/latest/documentation/reference/
+####
+
+set(SOURCE_FILES
+  "${CMAKE_CURRENT_LIST_DIR}/Types.fpp"
+)
+
+# Uncomment and add any modules that this module depends on, else
+# they might not be available when cmake tries to build this module.
+#
+# Module names are derived from the path from the nearest project/library/framework
+# root when not specifically overridden by the developer. i.e. The module defined by
+# `Ref/SignalGen/CMakeLists.txt` will be named `Ref_SignalGen`.  `Ref/SignalGen`
+# is an acceptable alternative and will be internally converted to `Ref_SignalGen`.
+#
+#set(MOD_DEPS
+#  MyPackage_MyOtherModule
+#)
+
+register_fprime_module() 

--- a/fprime-sensors/Bmp280/Types/Types.fpp
+++ b/fprime-sensors/Bmp280/Types/Types.fpp
@@ -1,0 +1,34 @@
+module Bmp280 {
+
+    @ Oversampling setting for pressure measurement
+    enum PressureOversampling : U8 {
+        SKIP = 0x00
+        OVERSAMPLE_1X = 0x04
+        OVERSAMPLE_2X = 0x08
+        OVERSAMPLE_4X = 0x0C
+        OVERSAMPLE_8X = 0x10
+        OVERSAMPLE_16X = 0x14
+    }
+
+    @ Oversampling setting for temperature measurement
+    enum TemperatureOversampling : U8 {
+        SKIP = 0x00
+        OVERSAMPLE_1X = 0x20
+        OVERSAMPLE_2X = 0x40
+        OVERSAMPLE_4X = 0x60
+        OVERSAMPLE_8X = 0x80
+        OVERSAMPLE_16X = 0xA0
+    }
+
+    @ Struct representing Bmp280 sensor data
+    struct Bmp280Data {
+        @ Pressure in Pascals (Pa)
+        pressure: F32
+        
+        @ Temperature in degrees Celsius (°C)
+        temperature: F32
+        
+        @ Altitude in meters (m)
+        altitude: F32
+    }
+} 

--- a/fprime-sensors/CMakeLists.txt
+++ b/fprime-sensors/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Helpers")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/NmeaGps")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/MpuImu")
+add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Bmp280")

--- a/fprime-sensors/MpuImu/Subtopology/MpuImuConfig/MpuImuSubtopologyConfig.fpp
+++ b/fprime-sensors/MpuImu/Subtopology/MpuImuConfig/MpuImuSubtopologyConfig.fpp
@@ -8,6 +8,9 @@ module MpuImu {
         if (not MpuImu::imuDriver.open(state.mpu.device)) {
             Fw::Logger::log("[ERROR] MPU IMU open failed\\n");
         }
+        else {
+            Fw::Logger::log("[INFO] MPU IMU open successful\\n");
+        }
         """
     }
 }

--- a/fprime-sensors/NmeaGps/Components/GpsManager/GpsManager.fpp
+++ b/fprime-sensors/NmeaGps/Components/GpsManager/GpsManager.fpp
@@ -6,10 +6,10 @@ module NmeaGps {
         telemetry Reading: GpsData
 
         @ Report for malformed message
-        event MalformedMessage(message_type: string, successful_fields: U8) severity warning low format "Malformed {} message after {} fields"
+        event MalformedMessage(message_type: string, successful_fields: U8) severity warning low format "Malformed {} message after {} fields" throttle 5 
 
         @ Report for invalid message
-        event InvalidData(message_type: string) severity warning low format "{} data  marked invalid"
+        event InvalidData(message_type: string) severity warning low format "{} data  marked invalid" throttle 5 
 
         ###############################################################################
         # Deframer "In" Ports: Mascarades as a deframer to use the FrameAccumulator   #


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| [#3831](https://github.com/nasa/fprime/issues/3831#issuecomment-3020799878) |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |
|**_Generative AI was used in this contribution (y/n)_**| y |

---
## Change Description

Updating the fprime-sensors to be able to use the BMP280 sensor. 

## Rationale

Adding BMP280 sensor to the sensors reference. 

## Testing/Review Recommendations

Follow the [FPrime Cross Compilation](https://fprime.jpl.nasa.gov/latest/docs/tutorials/cross-compilation/) tutorial when testing on hardware. 
For SPI connection, ensure pinout matches what is on the hardware to what is in Main.cpp (where the chip and device select are specified. (relevant for the [sensors-reference](https://github.com/fprime-community/fprime-sensors-reference))

## Future Work

In different sensor, the MPUIMU, its `sdd.md` needs to be written. 

## AI Usage ([policy](../AI_POLICY.md))

Used Cursor IDE for code generation, documenting how the sensor worked, debugging assistance, using it to summarize specific questions regarding the component. 
