### PR TITLE
Updates to fprime-sensors to work with fprime-zephyr

### DIFF
--- a/fprime-sensors/Helpers/Components/AccumulatorAdapter/AccumulatorAdapter.hpp
+++ b/fprime-sensors/Helpers/Components/AccumulatorAdapter/AccumulatorAdapter.hpp
@@ -24,7 +24,7 @@ class AccumulatorAdapter final : public AccumulatorAdapterComponentBase {
     //! Destroy AccumulatorAdapter object
     ~AccumulatorAdapter();
 
-  PRIVATE:
+  private:
     // ----------------------------------------------------------------------
     // Handler implementations for typed input ports
     // ----------------------------------------------------------------------

--- a/fprime-sensors/MpuImu/Components/ImuManager/ImuManager.cpp
+++ b/fprime-sensors/MpuImu/Components/ImuManager/ImuManager.cpp
@@ -194,13 +194,13 @@ ImuData ImuManager ::convert_raw_data(const RawImuData& raw,
                                       const GyroscopeRange& gyroscopeRange) {
     // Set the values of the IMU data by multiplying by conversion factors
     MpuImu::ImuData imuData;
-    imuData.getacceleration().setx(static_cast<F32>(raw.acceleration[0]) * 1.0f / static_cast<F32>(accelerationRange));
-    imuData.getacceleration().sety(static_cast<F32>(raw.acceleration[1]) * 1.0f / static_cast<F32>(accelerationRange));
-    imuData.getacceleration().setz(static_cast<F32>(raw.acceleration[2]) * 1.0f / static_cast<F32>(accelerationRange));
-    imuData.settemperature((static_cast<F32>(raw.temperature) / TEMPERATURE_SCALAR) + TEMPERATURE_OFFSET);
-    imuData.getrotation().setx(static_cast<F32>(raw.gyroscope[0]) * 10.0f / static_cast<F32>(gyroscopeRange));
-    imuData.getrotation().sety(static_cast<F32>(raw.gyroscope[1]) * 10.0f / static_cast<F32>(gyroscopeRange));
-    imuData.getrotation().setz(static_cast<F32>(raw.gyroscope[2]) * 10.0f / static_cast<F32>(gyroscopeRange));
+    imuData.get_acceleration().set_x(static_cast<F32>(raw.acceleration[0]) * 1.0f / static_cast<F32>(accelerationRange));
+    imuData.get_acceleration().set_y(static_cast<F32>(raw.acceleration[1]) * 1.0f / static_cast<F32>(accelerationRange));
+    imuData.get_acceleration().set_z(static_cast<F32>(raw.acceleration[2]) * 1.0f / static_cast<F32>(accelerationRange));
+    imuData.set_temperature((static_cast<F32>(raw.temperature) / TEMPERATURE_SCALAR) + TEMPERATURE_OFFSET);
+    imuData.get_rotation().set_x(static_cast<F32>(raw.gyroscope[0]) * 10.0f / static_cast<F32>(gyroscopeRange));
+    imuData.get_rotation().set_y(static_cast<F32>(raw.gyroscope[1]) * 10.0f / static_cast<F32>(gyroscopeRange));
+    imuData.get_rotation().set_z(static_cast<F32>(raw.gyroscope[2]) * 10.0f / static_cast<F32>(gyroscopeRange));
     return imuData;
 }
 

--- a/fprime-sensors/MpuImu/Subtopology/MpuImuConfig/CMakeLists.txt
+++ b/fprime-sensors/MpuImu/Subtopology/MpuImuConfig/CMakeLists.txt
@@ -3,4 +3,6 @@ register_fprime_config(
         "${CMAKE_CURRENT_LIST_DIR}/MpuImuSubtopologyConfig.fpp"
     DEPENDS
         Fw_Types
+    HEADERS
+        "${CMAKE_CURRENT_LIST_DIR}/MpuImuSubtopologyConfig.hpp"
 )

--- a/fprime-sensors/MpuImu/Subtopology/MpuImuConfig/MpuImuSubtopologyConfig.hpp
+++ b/fprime-sensors/MpuImu/Subtopology/MpuImuConfig/MpuImuSubtopologyConfig.hpp
@@ -5,9 +5,7 @@
 // ======================================================================
 #ifndef MpuImu_MpuImuSubtopologyConfig_hpp
 #define MpuImu_MpuImuSubtopologyConfig_hpp
-#include <zephyr/drivers/i2c.h>
-#undef EMPTY
 
-using ImuDevice = struct i2c_dt_spec;
+using ImuDevice = const char*;
 
 #endif // MpuImu_MpuImuSubtopologyConfig_hpp

--- a/fprime-sensors/MpuImu/Subtopology/MpuImuConfig/MpuImuSubtopologyConfig.hpp
+++ b/fprime-sensors/MpuImu/Subtopology/MpuImuConfig/MpuImuSubtopologyConfig.hpp
@@ -5,7 +5,9 @@
 // ======================================================================
 #ifndef MpuImu_MpuImuSubtopologyConfig_hpp
 #define MpuImu_MpuImuSubtopologyConfig_hpp
+#include <zephyr/drivers/i2c.h>
+#undef EMPTY
 
-using ImuDevice = const char*;
+using ImuDevice = struct i2c_dt_spec;
 
 #endif // MpuImu_MpuImuSubtopologyConfig_hpp

--- a/fprime-sensors/NmeaGps/Components/GpsManager/GpsManager.cpp
+++ b/fprime-sensors/NmeaGps/Components/GpsManager/GpsManager.cpp
@@ -47,9 +47,9 @@ void GpsManager ::parse_gga_message(const char* data, Fw::StringBase& messageHea
     }
     // Perform conversion
     else {
-        reading.setlatitude(this->ddmmmmmm_to_degrees(gga.latitude, gga.latitudeDirection));
-        reading.setlongitude(this->ddmmmmmm_to_degrees(gga.longitude, gga.longitudeDirection));
-        reading.setaltitude(gga.altitude * ((gga.altitudeUnits == 'F') ? 0.3048 : 1.0)); // Convert to meters if in feet
+        reading.set_latitude(this->ddmmmmmm_to_degrees(gga.latitude, gga.latitudeDirection));
+        reading.set_longitude(this->ddmmmmmm_to_degrees(gga.longitude, gga.longitudeDirection));
+        reading.set_altitude(gga.altitude * ((gga.altitudeUnits == 'F') ? 0.3048 : 1.0)); // Convert to meters if in feet
         this->tlmWrite_Reading(reading);
     }
 }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

<!-- A description of the changes contained in the PR. -->
Adding headers for sensors to have zephyi2c driver. 
Updating syntax. 
Changing `imu` type to be i2c device tree spec. 

## Rationale

<!-- A rationale for this change. e.g. fixes bug, or most projects need XYZ feature. -->
Wanting to have the [fprime-zephyr-reference ](https://github.com/fprime-community/fprime-zephyr-reference)work with the [fprime-sensors](https://github.com/fprime-community/fprime-sensors) library.

## Testing/Review Recommendations

<!-- Fill in testing procedures, specific items to focus on for review, or other info to help the team verify these changes are flight-quality. -->
n/a

## Future Work

<!-- Note any additional work that will be done relating to this issue. -->
Update other sensors to work with specific zephyr drivers. 

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

<!-- If AI was used, please describe how it was utilized (e.g., code generation, documentation, testing, debugging assistance, etc.). -->
n/a