### PR TITLE
Corrected RawImuData types

### DIFF
--- a/fprime-sensors/MpuImu/Components/ImuManager/ImuTypes.hpp
+++ b/fprime-sensors/MpuImu/Components/ImuManager/ImuTypes.hpp
@@ -32,9 +32,9 @@ namespace MpuImu {
 
     //! RawImuData: basic structure of imu data as read from the device
     struct RawImuData {
-        U16 acceleration[3];
-        U16 temperature;
-        U16 gyroscope[3];
+        I16 acceleration[3];
+        I16 temperature;
+        I16 gyroscope[3];
     };
 }
 #endif


### PR DESCRIPTION
See #7 for a full write-up of the issue. These values are stored in the sensor registers as signed 16-bit two's complement values and should be stored in this struct differently.