### PR TITLE
Update serialization/deserialization calls

### DIFF
--- a/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
+++ b/fprime-sensors/Bmp280/Components/BmpManager/BmpManager.cpp
@@ -312,12 +312,12 @@ BmpManager::RawBmpData BmpManager ::deserialize_raw_data(Fw::Buffer& buffer) {
     U8 pressure_msb, pressure_lsb, pressure_xlsb;
     U8 temperature_msb, temperature_lsb, temperature_xlsb;
 
-    deserializer.deserialize(pressure_msb);
-    deserializer.deserialize(pressure_lsb);
-    deserializer.deserialize(pressure_xlsb);
-    deserializer.deserialize(temperature_msb);
-    deserializer.deserialize(temperature_lsb);
-    deserializer.deserialize(temperature_xlsb);
+    deserializer.deserializeTo(pressure_msb);
+    deserializer.deserializeTo(pressure_lsb);
+    deserializer.deserializeTo(pressure_xlsb);
+    deserializer.deserializeTo(temperature_msb);
+    deserializer.deserializeTo(temperature_lsb);
+    deserializer.deserializeTo(temperature_xlsb);
 
     raw.pressure = (static_cast<U32>(pressure_msb) << 12) | (static_cast<U32>(pressure_lsb) << 4) |
                    (static_cast<U32>(pressure_xlsb) >> 4);

--- a/fprime-sensors/MpuImu/Components/ImuManager/ImuHelpers.cpp
+++ b/fprime-sensors/MpuImu/Components/ImuManager/ImuHelpers.cpp
@@ -89,13 +89,13 @@ Drv::I2cStatus ImuManager ::read(ImuData& imuData) {
 RawImuData ImuManager ::deserialize_raw_data(Fw::Buffer& buffer) {
     auto deserializer = buffer.getDeserializer();
     RawImuData raw;
-    deserializer.deserialize(raw.acceleration[0]);
-    deserializer.deserialize(raw.acceleration[1]);
-    deserializer.deserialize(raw.acceleration[2]);
-    deserializer.deserialize(raw.temperature);
-    deserializer.deserialize(raw.gyroscope[0]);
-    deserializer.deserialize(raw.gyroscope[1]);
-    deserializer.deserialize(raw.gyroscope[2]);
+    deserializer.deserializeTo(raw.acceleration[0]);
+    deserializer.deserializeTo(raw.acceleration[1]);
+    deserializer.deserializeTo(raw.acceleration[2]);
+    deserializer.deserializeTo(raw.temperature);
+    deserializer.deserializeTo(raw.gyroscope[0]);
+    deserializer.deserializeTo(raw.gyroscope[1]);
+    deserializer.deserializeTo(raw.gyroscope[2]);
     return raw;
 }
 

--- a/fprime-sensors/MpuImu/Components/ImuManager/test/ut/ImuManagerTester.cpp
+++ b/fprime-sensors/MpuImu/Components/ImuManager/test/ut/ImuManagerTester.cpp
@@ -21,7 +21,9 @@ ImuManagerTester ::ImuManagerTester()
     this->connectPorts();
 }
 
-ImuManagerTester ::~ImuManagerTester() {}
+ImuManagerTester ::~ImuManagerTester() {
+    this->component.deinit();
+}
 
 void ImuManagerTester ::tick() {
     this->invoke_to_run(0, 0);
@@ -148,13 +150,13 @@ void ImuManagerTester ::fill_read_data(Fw::Buffer& readBuffer) {
     raw.gyroscope[1] = STest::Pick::lowerUpper(0, 0xFFFF);
     raw.gyroscope[2] = STest::Pick::lowerUpper(0, 0xFFFF);
     auto serializer = readBuffer.getSerializer();
-    serializer.serialize(raw.acceleration[0]);
-    serializer.serialize(raw.acceleration[1]);
-    serializer.serialize(raw.acceleration[2]);
-    serializer.serialize(raw.temperature);
-    serializer.serialize(raw.gyroscope[0]);
-    serializer.serialize(raw.gyroscope[1]);
-    serializer.serialize(raw.gyroscope[2]);
+    serializer.serializeFrom(raw.acceleration[0]);
+    serializer.serializeFrom(raw.acceleration[1]);
+    serializer.serializeFrom(raw.acceleration[2]);
+    serializer.serializeFrom(raw.temperature);
+    serializer.serializeFrom(raw.gyroscope[0]);
+    serializer.serializeFrom(raw.gyroscope[1]);
+    serializer.serializeFrom(raw.gyroscope[2]);
     this->imuData = ImuManager::convert_raw_data(raw, this->accelerationRange, this->gyroscopeRange);
 }
 


### PR DESCRIPTION
While updating a project of mine to be compatible with fprime v4.1.1 I noticed some compiler warnings from this repo related to using deprecated functions. These changes update the serialization/deserialization calls to use the non-deprecated versions first introduced with fprime v4.1.0. I've also added component deinitialization to a unit test destructor to address leak warnings I was getting when I ran unit tests for the IMU to confirm they still pass after the serialization changes.